### PR TITLE
feat(overview): keep edge-day data visible during week changes

### DIFF
--- a/apps/api/src/routes/standings.route.ts
+++ b/apps/api/src/routes/standings.route.ts
@@ -23,8 +23,9 @@ standings.get(
   '/start-top-five',
   async (req: Request, res: Response): Promise<Response> => {
     const date = String(req.query.date);
+    const withEdgeDays = req.query.withEdgeDays === 'true';
     const standingsController = new StandingsController();
-    const weekDates = getWeekDatesArray(date);
+    const weekDates = getWeekDatesArray(date, withEdgeDays);
     const weekData = await Promise.all(
       weekDates.map((day) => standingsController.getTopFive(day))
     );

--- a/apps/client/src/app/features/overview/components/content/content.component.ts
+++ b/apps/client/src/app/features/overview/components/content/content.component.ts
@@ -61,6 +61,7 @@ export class HideHeaderDirective implements OnInit {
             class="fixtures-container"
             [filteredFixtures]="fixtures"
             [isLoading]="fixturesLoading()"
+            [hasDataForSelectedDay]="hasFixturesDataForSelectedDay()"
             [error]="fixturesError()"
           />
           } @if (standings) {
@@ -68,6 +69,7 @@ export class HideHeaderDirective implements OnInit {
             class="standings-container"
             [weekStandings]="standings"
             [isLoading]="standingsLoading()"
+            [hasDataForSelectedDay]="hasStandingsDataForSelectedDay()"
             [error]="standingsError()"
           />
           }
@@ -78,6 +80,8 @@ export class HideHeaderDirective implements OnInit {
   `,
 })
 export class OverviewContentComponent {
+  readonly animationDuration = MAT_TAB_ANIMATION_DURATION;
+
   private readonly facade = inject(OverviewContentFacade);
   readonly tabIndex = this.facade.tabIndex;
   readonly weekdays = this.facade.weekdays;
@@ -85,10 +89,12 @@ export class OverviewContentComponent {
   readonly weekFixtures = this.facade.weekFixtures;
   readonly fixturesLoading = this.facade.fixturesLoading;
   readonly fixturesError = this.facade.fixturesError;
+  readonly hasFixturesDataForSelectedDay =
+    this.facade.hasFixturesDataForSelectedDay;
 
   readonly weekStandings = this.facade.weekStandings;
   readonly standingsLoading = this.facade.standingsLoading;
   readonly standingsError = this.facade.standingsError;
-
-  readonly animationDuration = MAT_TAB_ANIMATION_DURATION;
+  readonly hasStandingsDataForSelectedDay =
+    this.facade.hasStandingsDataForSelectedDay;
 }

--- a/apps/client/src/app/features/overview/components/content/content.facade.spec.ts
+++ b/apps/client/src/app/features/overview/components/content/content.facade.spec.ts
@@ -1,8 +1,19 @@
 import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
-import { formatCalendarWeekKey, type DateString } from '@lib/shared';
+import type {
+  ExtendedFixtureDTO,
+  FixturesWeekData,
+  StandingsDTO,
+  StandingsWeekData,
+} from '@lib/models';
+import {
+  COMPETITION_ID,
+  formatCalendarWeekKey,
+  type DateString,
+} from '@lib/shared';
 
+import { EXAMPLE_FIXTURE } from '../../../../../testing/fixtures.mock';
 import { DateNavigationService, SelectedDateService } from '../../services';
 import { WeekFixturesStore, WeekStandingsStore } from '../../stores';
 
@@ -11,7 +22,10 @@ import { OverviewContentFacade } from './content.facade';
 describe('OverviewContentFacade', () => {
   const initialDate: DateString = '2026-08-10';
   const sameWeekDate: DateString = '2026-08-12';
-  const nextWeekDate: DateString = '2026-08-17';
+
+  const previousSunday: DateString = '2026-08-09';
+  const currentSunday: DateString = '2026-08-16';
+  const nextMonday: DateString = '2026-08-17';
 
   const selectedDay = signal<DateString>(initialDate);
 
@@ -20,13 +34,15 @@ describe('OverviewContentFacade', () => {
     setSelectedDay: jest.fn(),
   };
 
+  const selectedTabIndex = signal(0);
+
   const dateNavigationServiceMock = {
-    selectedTabIndex: signal(0),
+    selectedTabIndex: selectedTabIndex.asReadonly(),
   };
 
   const fixturesStoreMock = {
     weekKey: signal<string | null>(null),
-    weekFixtures: signal([]),
+    weekFixtures: signal<FixturesWeekData>(createEmptyFixturesWeekData()),
     isLoading: signal(false),
     error: signal<string | null>(null),
     loadWeekFixtures: jest.fn(),
@@ -34,7 +50,7 @@ describe('OverviewContentFacade', () => {
 
   const standingsStoreMock = {
     weekKey: signal<string | null>(null),
-    weekStandings: signal([]),
+    weekStandings: signal<StandingsWeekData>(createEmptyStandingsWeekData()),
     isLoading: signal(false),
     error: signal<string | null>(null),
     loadWeekStandings: jest.fn(),
@@ -42,9 +58,13 @@ describe('OverviewContentFacade', () => {
 
   beforeEach(() => {
     selectedDay.set(initialDate);
+    selectedTabIndex.set(0);
 
     fixturesStoreMock.weekKey.set(null);
     standingsStoreMock.weekKey.set(null);
+
+    fixturesStoreMock.weekFixtures.set(createEmptyFixturesWeekData());
+    standingsStoreMock.weekStandings.set(createEmptyStandingsWeekData());
 
     fixturesStoreMock.loadWeekFixtures.mockClear();
     standingsStoreMock.loadWeekStandings.mockClear();
@@ -115,15 +135,12 @@ describe('OverviewContentFacade', () => {
     fixturesStoreMock.loadWeekFixtures.mockClear();
     standingsStoreMock.loadWeekStandings.mockClear();
 
-    selectedDay.set(nextWeekDate);
+    selectedDay.set(nextMonday);
     TestBed.tick();
 
-    expect(fixturesStoreMock.loadWeekFixtures).toHaveBeenCalledWith(
-      nextWeekDate
-    );
-
+    expect(fixturesStoreMock.loadWeekFixtures).toHaveBeenCalledWith(nextMonday);
     expect(standingsStoreMock.loadWeekStandings).toHaveBeenCalledWith(
-      nextWeekDate
+      nextMonday
     );
   });
 
@@ -165,6 +182,189 @@ describe('OverviewContentFacade', () => {
     expect(facade.standingsError()).toBeNull();
   });
 
+  describe('week data mapping', () => {
+    it('should expose empty weekday data during the initial load', () => {
+      fixturesStoreMock.isLoading.set(true);
+
+      const facade = TestBed.inject(OverviewContentFacade);
+      TestBed.tick();
+
+      expect(facade.weekFixtures()).toEqual([[], [], [], [], [], [], []]);
+
+      expect(facade.hasFixturesDataForSelectedDay()).toBe(false);
+    });
+
+    it('should map the nine loaded fixture days to the seven visible weekdays', () => {
+      const weekData = createIndexedFixturesWeekData();
+
+      fixturesStoreMock.weekFixtures.set(weekData);
+      fixturesStoreMock.weekKey.set(formatCalendarWeekKey(initialDate));
+
+      const facade = TestBed.inject(OverviewContentFacade);
+      TestBed.tick();
+
+      expect(facade.weekFixtures()).toEqual(weekData.slice(1, 8));
+    });
+
+    it('should keep the edge monday visible while the next week is loading', () => {
+      const weekData = createIndexedFixturesWeekData();
+
+      fixturesStoreMock.weekFixtures.set(weekData);
+      fixturesStoreMock.weekKey.set(formatCalendarWeekKey(initialDate));
+
+      const facade = TestBed.inject(OverviewContentFacade);
+      TestBed.tick();
+
+      selectedDay.set(nextMonday);
+      selectedTabIndex.set(0);
+      fixturesStoreMock.isLoading.set(true);
+
+      TestBed.tick();
+
+      expect(facade.weekFixtures()[0]).toBe(weekData[8]);
+      expect(facade.hasFixturesDataForSelectedDay()).toBe(true);
+    });
+
+    it('should keep the edge sunday visible while the previous week is loading', () => {
+      const currentWeekDate: DateString = '2026-08-17';
+
+      const weekData = createIndexedFixturesWeekData();
+
+      fixturesStoreMock.weekFixtures.set(weekData);
+      fixturesStoreMock.weekKey.set(formatCalendarWeekKey(currentWeekDate));
+
+      selectedDay.set(currentWeekDate);
+
+      const facade = TestBed.inject(OverviewContentFacade);
+      TestBed.tick();
+
+      selectedDay.set(currentSunday);
+      selectedTabIndex.set(6);
+      fixturesStoreMock.isLoading.set(true);
+
+      TestBed.tick();
+
+      expect(facade.weekFixtures()[6]).toBe(weekData[0]);
+      expect(facade.hasFixturesDataForSelectedDay()).toBe(true);
+    });
+
+    it('should replace edge monday data with regular monday data when the next week finishes loading', () => {
+      const currentWeekData = createIndexedFixturesWeekData();
+      const nextWeekData = createIndexedFixturesWeekData(100);
+
+      fixturesStoreMock.weekFixtures.set(currentWeekData);
+      fixturesStoreMock.weekKey.set(formatCalendarWeekKey(initialDate));
+
+      const facade = TestBed.inject(OverviewContentFacade);
+      TestBed.tick();
+
+      selectedDay.set(nextMonday);
+      selectedTabIndex.set(0);
+      fixturesStoreMock.isLoading.set(true);
+
+      TestBed.tick();
+
+      expect(facade.weekFixtures()[0]).toBe(currentWeekData[8]);
+
+      fixturesStoreMock.weekFixtures.set(nextWeekData);
+      fixturesStoreMock.weekKey.set(formatCalendarWeekKey(nextMonday));
+      fixturesStoreMock.isLoading.set(false);
+
+      TestBed.tick();
+
+      expect(facade.weekFixtures()[0]).toBe(nextWeekData[1]);
+      expect(facade.hasFixturesDataForSelectedDay()).toBe(true);
+    });
+
+    it('should not expose cached data for a selected day outside the edge-day range', () => {
+      const dateOutsideEdgeRange: DateString = '2026-08-18';
+      const weekData = createIndexedFixturesWeekData();
+
+      fixturesStoreMock.weekFixtures.set(weekData);
+      fixturesStoreMock.weekKey.set(formatCalendarWeekKey(initialDate));
+
+      const facade = TestBed.inject(OverviewContentFacade);
+      TestBed.tick();
+
+      selectedDay.set(dateOutsideEdgeRange);
+      selectedTabIndex.set(1);
+
+      TestBed.tick();
+
+      expect(facade.hasFixturesDataForSelectedDay()).toBe(false);
+      expect(facade.weekFixtures()[1]).toBeUndefined();
+    });
+  });
+
+  describe('edge-day availability', () => {
+    it('should report fixture data as available for the previous sunday edge day', () => {
+      fixturesStoreMock.weekKey.set(formatCalendarWeekKey(initialDate));
+
+      const facade = TestBed.inject(OverviewContentFacade);
+      TestBed.tick();
+
+      selectedDay.set(previousSunday);
+
+      expect(facade.hasFixturesDataForSelectedDay()).toBe(true);
+    });
+
+    it('should report fixture data as available for the next monday edge day', () => {
+      fixturesStoreMock.weekKey.set(formatCalendarWeekKey(initialDate));
+
+      const facade = TestBed.inject(OverviewContentFacade);
+      TestBed.tick();
+
+      selectedDay.set(nextMonday);
+
+      expect(facade.hasFixturesDataForSelectedDay()).toBe(true);
+    });
+
+    it('should report fixture data as unavailable before the previous sunday', () => {
+      const dateBeforeEdgeRange: DateString = '2026-08-08';
+
+      fixturesStoreMock.weekKey.set(formatCalendarWeekKey(initialDate));
+
+      const facade = TestBed.inject(OverviewContentFacade);
+      TestBed.tick();
+
+      selectedDay.set(dateBeforeEdgeRange);
+
+      expect(facade.hasFixturesDataForSelectedDay()).toBe(false);
+    });
+
+    it('should report fixture data as unavailable after the next monday', () => {
+      const dateAfterEdgeRange: DateString = '2026-08-18';
+
+      fixturesStoreMock.weekKey.set(formatCalendarWeekKey(initialDate));
+
+      const facade = TestBed.inject(OverviewContentFacade);
+      TestBed.tick();
+
+      selectedDay.set(dateAfterEdgeRange);
+
+      expect(facade.hasFixturesDataForSelectedDay()).toBe(false);
+    });
+
+    it('should keep standings edge-day data available while the next week is loading', () => {
+      const weekData = createIndexedStandingsWeekData();
+
+      standingsStoreMock.weekStandings.set(weekData);
+      standingsStoreMock.weekKey.set(formatCalendarWeekKey(initialDate));
+
+      const facade = TestBed.inject(OverviewContentFacade);
+      TestBed.tick();
+
+      selectedDay.set(nextMonday);
+      selectedTabIndex.set(0);
+      standingsStoreMock.isLoading.set(true);
+
+      TestBed.tick();
+
+      expect(facade.weekStandings()[0]).toBe(weekData[8]);
+      expect(facade.hasStandingsDataForSelectedDay()).toBe(true);
+    });
+  });
+
   const markWeekAsCached = (date: DateString): void => {
     const weekKey = formatCalendarWeekKey(date);
 
@@ -172,3 +372,44 @@ describe('OverviewContentFacade', () => {
     standingsStoreMock.weekKey.set(weekKey);
   };
 });
+
+function createEmptyFixturesWeekData(): FixturesWeekData {
+  return Array.from({ length: 7 }, () => []);
+}
+
+function createEmptyStandingsWeekData(): StandingsWeekData {
+  return Array.from({ length: 7 }, () => []);
+}
+
+function createIndexedFixturesWeekData(startId = 0): FixturesWeekData {
+  return Array.from({ length: 9 }, (_, index) => [
+    {
+      ...EXAMPLE_FIXTURE,
+      fixture: {
+        ...EXAMPLE_FIXTURE.fixture,
+        id: startId + index,
+      },
+    } as ExtendedFixtureDTO,
+  ]);
+}
+
+function createIndexedStandingsWeekData(): StandingsWeekData {
+  return Array.from({ length: 9 }, () => [createStandings()]);
+}
+
+function createStandings(): StandingsDTO {
+  return {
+    _id: 'test-1',
+    league: {
+      id: COMPETITION_ID.GERMANY_BUNDESLIGA,
+      name: 'Bundesliga',
+      country: 'Germany',
+      logo: 'bundesliga-logo',
+      flag: 'germany-flag',
+      season: 2026,
+      standings: [],
+    },
+    createdAt: new Date('2026-08-10'),
+    updatedAt: new Date('2026-08-10'),
+  };
+}

--- a/apps/client/src/app/features/overview/components/content/content.facade.ts
+++ b/apps/client/src/app/features/overview/components/content/content.facade.ts
@@ -1,9 +1,23 @@
 import { computed, effect, inject, Injectable, untracked } from '@angular/core';
 
-import { formatCalendarWeekKey, type DateString } from '@lib/shared';
+import {
+  addDays,
+  formatCalendarWeekKey,
+  getWeekStartFromKey,
+  type DateString,
+} from '@lib/shared';
 
 import { DateNavigationService, SelectedDateService } from '../../services';
 import { WeekFixturesStore, WeekStandingsStore } from '../../stores';
+
+const EDGE_PREVIOUS_DAY_INDEX = 0;
+const CURRENT_WEEK_START_INDEX = 1;
+const CURRENT_WEEK_END_INDEX = 7;
+const EDGE_NEXT_DAY_INDEX = 8;
+
+const UI_WEEK_FIRST_INDEX = 0;
+const UI_WEEK_LAST_INDEX = 6;
+const UI_DAYS_PER_WEEK = 7;
 
 @Injectable()
 export class OverviewContentFacade {
@@ -11,16 +25,15 @@ export class OverviewContentFacade {
 
   private readonly dateNavigationService = inject(DateNavigationService);
   private readonly selectedDateService = inject(SelectedDateService);
+
   private readonly selectedDay = this.selectedDateService.selectedDay;
   readonly tabIndex = this.dateNavigationService.selectedTabIndex;
 
   private readonly weekFixturesStore = inject(WeekFixturesStore);
-  readonly weekFixtures = this.weekFixturesStore.weekFixtures;
   readonly fixturesLoading = this.weekFixturesStore.isLoading;
   readonly fixturesError = this.weekFixturesStore.error;
 
   private readonly weekStandingsStore = inject(WeekStandingsStore);
-  readonly weekStandings = this.weekStandingsStore.weekStandings;
   readonly standingsLoading = this.weekStandingsStore.isLoading;
   readonly standingsError = this.weekStandingsStore.error;
 
@@ -28,17 +41,48 @@ export class OverviewContentFacade {
     () => this.selectedDay().split('T')[0]
   );
 
-  private readonly weekKey = computed(() => {
-    const date: DateString = this.selectedDateString();
-    return formatCalendarWeekKey(date);
-  });
+  private readonly weekKey = computed(() =>
+    formatCalendarWeekKey(this.selectedDateString())
+  );
 
-  readonly calendarWeekEffect = effect(() => {
+  readonly weekFixtures = computed(() =>
+    getVisibleWeekData(
+      this.weekFixturesStore.weekFixtures(),
+      this.weekFixturesStore.weekKey(),
+      this.selectedDateString()
+    )
+  );
+
+  readonly weekStandings = computed(() =>
+    getVisibleWeekData(
+      this.weekStandingsStore.weekStandings(),
+      this.weekStandingsStore.weekKey(),
+      this.selectedDateString()
+    )
+  );
+
+  readonly hasFixturesDataForSelectedDay = computed(() =>
+    hasDataForSelectedDay(
+      this.weekFixturesStore.weekKey(),
+      this.selectedDateString()
+    )
+  );
+
+  readonly hasStandingsDataForSelectedDay = computed(() =>
+    hasDataForSelectedDay(
+      this.weekStandingsStore.weekKey(),
+      this.selectedDateString()
+    )
+  );
+
+  private readonly calendarWeekEffect = effect(() => {
     const weekKey = this.weekKey();
 
-    const isCached =
-      this.weekFixturesStore.weekKey() === weekKey &&
-      this.weekStandingsStore.weekKey() === weekKey;
+    const isCached = untracked(
+      () =>
+        this.weekFixturesStore.weekKey() === weekKey &&
+        this.weekStandingsStore.weekKey() === weekKey
+    );
 
     if (isCached) {
       return;
@@ -49,4 +93,58 @@ export class OverviewContentFacade {
     this.weekFixturesStore.loadWeekFixtures(date);
     this.weekStandingsStore.loadWeekStandings(date);
   });
+}
+
+function getVisibleWeekData<T>(
+  data: T[],
+  cachedWeekKey: string | null,
+  selectedDay: DateString
+): Array<T | undefined> {
+  if (cachedWeekKey === null) {
+    return data;
+  }
+
+  if (cachedWeekKey === formatCalendarWeekKey(selectedDay)) {
+    return data.slice(CURRENT_WEEK_START_INDEX, CURRENT_WEEK_END_INDEX + 1);
+  }
+
+  const weekStart = getWeekStartFromKey(cachedWeekKey);
+
+  if (selectedDay === addDays(weekStart, 7)) {
+    return createEdgeWeekData(UI_WEEK_FIRST_INDEX, data[EDGE_NEXT_DAY_INDEX]);
+  }
+
+  if (selectedDay === addDays(weekStart, -1)) {
+    return createEdgeWeekData(
+      UI_WEEK_LAST_INDEX,
+      data[EDGE_PREVIOUS_DAY_INDEX]
+    );
+  }
+
+  return Array(UI_DAYS_PER_WEEK).fill(undefined);
+}
+
+function createEdgeWeekData<T>(
+  index: number,
+  edgeDayData: T | undefined
+): Array<T | undefined> {
+  const weekData = Array<T | undefined>(UI_DAYS_PER_WEEK).fill(undefined);
+  weekData[index] = edgeDayData;
+
+  return weekData;
+}
+
+function hasDataForSelectedDay(
+  cachedWeekKey: string | null,
+  selectedDay: DateString
+): boolean {
+  if (cachedWeekKey === null) {
+    return false;
+  }
+
+  const weekStart = getWeekStartFromKey(cachedWeekKey);
+  const previousSunday = addDays(weekStart, -1);
+  const nextMonday = addDays(weekStart, 7);
+
+  return selectedDay >= previousSunday && selectedDay <= nextMonday;
 }

--- a/apps/client/src/app/features/overview/components/content/fixtures/fixtures.component.spec.ts
+++ b/apps/client/src/app/features/overview/components/content/fixtures/fixtures.component.spec.ts
@@ -1,13 +1,32 @@
+import { Component, input } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
+import type { CompetitionWithFixtures } from '@app/shared';
 import type { ExtendedFixtureDTO } from '@lib/models';
+
+import { EXAMPLE_FIXTURE } from '../../../../../../testing/fixtures.mock';
 
 import { OverviewFixturesComponent } from './fixtures.component';
 import { OverviewFixturesFacade } from './fixtures.facade';
+import { MatchDayListComponent } from './match-day-list.component';
+
+@Component({
+  selector: 'rs-start-match-day-list',
+  standalone: true,
+  template: '',
+})
+class MatchDayListStubComponent {
+  readonly competition = input.required<CompetitionWithFixtures>();
+}
 
 describe('OverviewFixturesComponent', () => {
-  const facadeMock = {
-    initCompetitionsWithFixtures: jest.fn(() => []),
+  const facadeMock: {
+    initCompetitionsWithFixtures: jest.Mock<
+      CompetitionWithFixtures[],
+      [ExtendedFixtureDTO[] | null]
+    >;
+  } = {
+    initCompetitionsWithFixtures: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -15,7 +34,12 @@ describe('OverviewFixturesComponent', () => {
       imports: [OverviewFixturesComponent],
     })
       .overrideComponent(OverviewFixturesComponent, {
-        set: {
+        remove: {
+          imports: [MatchDayListComponent],
+          providers: [OverviewFixturesFacade],
+        },
+        add: {
+          imports: [MatchDayListStubComponent],
           providers: [
             {
               provide: OverviewFixturesFacade,
@@ -33,16 +57,22 @@ describe('OverviewFixturesComponent', () => {
   const createComponent = ({
     fixtures = [],
     isLoading = false,
+    hasDataForSelectedDay = false,
     error = null,
   }: {
     fixtures?: ExtendedFixtureDTO[];
     isLoading?: boolean;
+    hasDataForSelectedDay?: boolean;
     error?: string | null;
   } = {}) => {
     const fixture = TestBed.createComponent(OverviewFixturesComponent);
 
     fixture.componentRef.setInput('filteredFixtures', fixtures);
     fixture.componentRef.setInput('isLoading', isLoading);
+    fixture.componentRef.setInput(
+      'hasDataForSelectedDay',
+      hasDataForSelectedDay
+    );
     fixture.componentRef.setInput('error', error);
 
     fixture.detectChanges();
@@ -58,9 +88,10 @@ describe('OverviewFixturesComponent', () => {
     );
   });
 
-  it('should display a loading state while fixtures are loading', () => {
+  it('should display a loading state while fixtures are loading and no cached data is available', () => {
     const fixture = createComponent({
       isLoading: true,
+      hasDataForSelectedDay: false,
     });
 
     expect(
@@ -70,6 +101,47 @@ describe('OverviewFixturesComponent', () => {
     expect(fixture.nativeElement.textContent).not.toContain(
       'Es finden keine Spiele statt.'
     );
+  });
+
+  it('should not display the loading state while cached edge-day data is available', () => {
+    const fixture = createComponent({
+      isLoading: true,
+      hasDataForSelectedDay: true,
+    });
+
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="fixtures-loading"]')
+    ).toBeNull();
+
+    expect(fixture.nativeElement.textContent).toContain(
+      'Es finden keine Spiele statt.'
+    );
+  });
+
+  it('should keep fixtures visible while the next week is loading', () => {
+    const competition: CompetitionWithFixtures = {
+      id: EXAMPLE_FIXTURE.league.id,
+      name: EXAMPLE_FIXTURE.league.name,
+      image: EXAMPLE_FIXTURE.league.flag || 'error',
+      url: ['/', 'competition', 'champions-league'],
+      fixtures: [EXAMPLE_FIXTURE],
+    };
+
+    facadeMock.initCompetitionsWithFixtures.mockReturnValue([competition]);
+
+    const fixture = createComponent({
+      fixtures: [EXAMPLE_FIXTURE],
+      isLoading: true,
+      hasDataForSelectedDay: true,
+    });
+
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="fixtures-loading"]')
+    ).toBeNull();
+
+    expect(
+      fixture.nativeElement.querySelector('rs-start-match-day-list')
+    ).not.toBeNull();
   });
 
   it('should display an error state when fixtures could not be loaded', () => {
@@ -86,9 +158,10 @@ describe('OverviewFixturesComponent', () => {
     );
   });
 
-  it('should prefer the loading state while fixtures are loading', () => {
+  it('should prefer the loading state over an error when no cached data is available', () => {
     const fixture = createComponent({
       isLoading: true,
+      hasDataForSelectedDay: false,
       error: 'Request failed',
     });
 
@@ -99,5 +172,17 @@ describe('OverviewFixturesComponent', () => {
     expect(fixture.nativeElement.textContent).not.toContain(
       'Fehler beim Laden der Spiele.'
     );
+  });
+
+  it('should prefer cached data over the loading state', () => {
+    const fixture = createComponent({
+      isLoading: true,
+      hasDataForSelectedDay: true,
+      error: 'Request failed',
+    });
+
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="fixtures-loading"]')
+    ).toBeNull();
   });
 });

--- a/apps/client/src/app/features/overview/components/content/fixtures/fixtures.component.ts
+++ b/apps/client/src/app/features/overview/components/content/fixtures/fixtures.component.ts
@@ -30,7 +30,7 @@ import { MatchDayListComponent } from './match-day-list.component';
     />
     } } @else {
     <p class="no-data">
-      @if (isLoading()) {
+      @if (isLoading() && !hasDataForSelectedDay()) {
       <span data-testid="fixtures-loading">Spiele werden geladen ...</span> }
       @else { @if (error()) { Fehler beim Laden der Spiele. } @else if
       (fixtures.length === 0) { Es finden keine Spiele statt. } }
@@ -39,11 +39,12 @@ import { MatchDayListComponent } from './match-day-list.component';
   `,
 })
 export class OverviewFixturesComponent {
-  filteredFixtures = input.required<ExtendedFixtureDTO[]>();
-  isLoading = input.required<boolean>();
-  error = input.required<string | null>();
+  readonly filteredFixtures = input.required<ExtendedFixtureDTO[]>();
+  readonly isLoading = input.required<boolean>();
+  readonly hasDataForSelectedDay = input.required<boolean>();
+  readonly error = input.required<string | null>();
 
-  facade = inject(OverviewFixturesFacade);
+  private readonly facade = inject(OverviewFixturesFacade);
 
   // TODO check if this signal can be moved to facade, depend on filteredFixtures is a problem
   competitions = computed<CompetitionWithFixtures[]>(() => {

--- a/apps/client/src/app/features/overview/components/content/standings/standings.component.spec.ts
+++ b/apps/client/src/app/features/overview/components/content/standings/standings.component.spec.ts
@@ -56,16 +56,22 @@ describe('OverviewStandingsComponent', () => {
   const createComponent = ({
     standings = [],
     isLoading = false,
+    hasDataForSelectedDay = false,
     error = null,
   }: {
     standings?: StandingsDTO[];
     isLoading?: boolean;
+    hasDataForSelectedDay?: boolean;
     error?: string | null;
   } = {}) => {
     const fixture = TestBed.createComponent(OverviewStandingsComponent);
 
     fixture.componentRef.setInput('weekStandings', standings);
     fixture.componentRef.setInput('isLoading', isLoading);
+    fixture.componentRef.setInput(
+      'hasDataForSelectedDay',
+      hasDataForSelectedDay
+    );
     fixture.componentRef.setInput('error', error);
 
     fixture.detectChanges();
@@ -81,18 +87,26 @@ describe('OverviewStandingsComponent', () => {
     );
   });
 
-  it('should display a loading state while standings are loading', () => {
+  it('should display a loading state while standings are loading and no cached data is available', () => {
     const fixture = createComponent({
       isLoading: true,
+      hasDataForSelectedDay: false,
     });
 
-    expect(fixture.nativeElement.textContent).toContain(
-      'Tabellen werden geladen ...'
-    );
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="standings-loading"]')
+    ).not.toBeNull();
+  });
 
-    expect(fixture.nativeElement.textContent).not.toContain(
-      'Keine Tabellen gefunden.'
-    );
+  it('should not display the loading state while cached edge-day data is available', () => {
+    const fixture = createComponent({
+      isLoading: true,
+      hasDataForSelectedDay: true,
+    });
+
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="standings-loading"]')
+    ).toBeNull();
   });
 
   it('should display an error state when standings could not be loaded', () => {

--- a/apps/client/src/app/features/overview/components/content/standings/standings.component.ts
+++ b/apps/client/src/app/features/overview/components/content/standings/standings.component.ts
@@ -55,8 +55,10 @@ import { OverviewStandingsFacade } from './standings.facade';
       [ranks]="standing.league.standings![0]"
       [league]="standing.league"
     />
-    } } @else if (isLoading()) {
-    <p class="no-data">Tabellen werden geladen ...</p>
+    } } @else if (isLoading() && !hasDataForSelectedDay()) {
+    <p class="no-data" data-testid="standings-loading">
+      Tabellen werden geladen ...
+    </p>
     } @else if (error()) {
     <p class="no-data">Fehler beim Laden der Tabellen.</p>
     } @else if (!isLoading()) {
@@ -65,18 +67,19 @@ import { OverviewStandingsFacade } from './standings.facade';
   `,
 })
 export class OverviewStandingsComponent {
-  weekStandings = input.required<StandingsDTO[]>();
-  isLoading = input.required<boolean>();
-  error = input.required<string | null>();
+  readonly weekStandings = input.required<StandingsDTO[]>();
+  readonly isLoading = input.required<boolean>();
+  readonly hasDataForSelectedDay = input.required<boolean>();
+  readonly error = input.required<string | null>();
 
-  facade = inject(OverviewStandingsFacade);
-  dayStandings = this.facade.dayStandings;
-  isFiltering = this.facade.isFiltering;
-  hasMultipleGroups = this.facade.hasMultipleGroups;
-  showHomeAndAwayStandings = this.facade.showHomeAndAwayStandings;
+  private readonly facade = inject(OverviewStandingsFacade);
+  readonly dayStandings = this.facade.dayStandings;
+  readonly isFiltering = this.facade.isFiltering;
+  readonly hasMultipleGroups = this.facade.hasMultipleGroups;
+  readonly showHomeAndAwayStandings = this.facade.showHomeAndAwayStandings;
 
   // TODO check if this signal can be moved to facade, depend on weekStandings is a problem (1/2)
-  showTopFive = computed<boolean>(() => {
+  readonly showTopFive = computed<boolean>(() => {
     const standings = this.weekStandings();
     if (!standings) return false;
     return standings.length === 5;

--- a/apps/client/src/app/features/overview/components/date-bar/week-toggle-group.component.ts
+++ b/apps/client/src/app/features/overview/components/date-bar/week-toggle-group.component.ts
@@ -113,7 +113,7 @@ const EXTERNAL_MODULES = [
         [value]="selectedDay()"
         (valueChange)="toggleValueChange($event)"
       >
-        @for(day of weekdays(); track day) {
+        @for (day of weekdays(); track $index) {
         <mat-button-toggle
           [disabled]="isLoading() || selectedDay() === day"
           [value]="day"

--- a/apps/client/src/app/features/overview/stores/week-fixtures.store.ts
+++ b/apps/client/src/app/features/overview/stores/week-fixtures.store.ts
@@ -36,11 +36,10 @@ export const WeekFixturesStore = signalStore(
         tap(({ updateOnly }) => {
           patchState(store, {
             ...getWeekRequestStartPatch(updateOnly),
-            ...(updateOnly ? {} : { weekFixtures: createEmptyWeekFixtures() }),
           });
         }),
 
-        switchMap(({ date, updateOnly }) =>
+        switchMap(({ date }) =>
           http.getWeekFixtures(date).pipe(
             retry(errorHandler),
 
@@ -57,9 +56,6 @@ export const WeekFixturesStore = signalStore(
               patchState(store, {
                 ...WEEK_REQUEST_END_PATCH,
                 error,
-                ...(updateOnly
-                  ? {}
-                  : { weekKey: null, weekFixtures: createEmptyWeekFixtures() }),
               });
 
               return EMPTY;

--- a/apps/client/src/app/features/overview/stores/week-standings.store.spec.ts
+++ b/apps/client/src/app/features/overview/stores/week-standings.store.spec.ts
@@ -119,14 +119,14 @@ describe('WeekStandingsStore', () => {
     expect(store.weekStandings()).toBe(secondWeek);
   });
 
-  it('should clear standings when loading a new week fails', async () => {
+  it('should preserve existing standings when loading a new week fails', async () => {
     jest.useFakeTimers();
 
-    const currentWeek = createWeekStandings();
-    const error = new Error('Failed to load standings');
+    const existingStandings = createWeekStandings();
+    const error = new Error('Request failed');
 
     httpMock.getWeekStandings
-      .mockReturnValueOnce(of(currentWeek))
+      .mockReturnValueOnce(of(existingStandings))
       .mockReturnValueOnce(throwError(() => error));
 
     store.loadWeekStandings(testDate);
@@ -134,7 +134,7 @@ describe('WeekStandingsStore', () => {
 
     await jest.runAllTimersAsync();
 
-    expect(store.weekStandings()).toEqual(createEmptyWeekStandings());
+    expect(store.weekStandings()).toBe(existingStandings);
     expect(store.isLoading()).toBe(false);
     expect(store.isPending()).toBe(false);
     expect(store.error()).toBe(error);

--- a/apps/client/src/app/features/overview/stores/week-standings.store.ts
+++ b/apps/client/src/app/features/overview/stores/week-standings.store.ts
@@ -36,13 +36,10 @@ export const WeekStandingsStore = signalStore(
         tap(({ updateOnly }) => {
           patchState(store, {
             ...getWeekRequestStartPatch(updateOnly),
-            ...(updateOnly
-              ? {}
-              : { weekStandings: createEmptyWeekStandings() }),
           });
         }),
 
-        switchMap(({ date, updateOnly }) =>
+        switchMap(({ date }) =>
           http.getWeekStandings(date).pipe(
             retry(errorHandler),
 
@@ -59,12 +56,6 @@ export const WeekStandingsStore = signalStore(
               patchState(store, {
                 ...WEEK_REQUEST_END_PATCH,
                 error,
-                ...(updateOnly
-                  ? {}
-                  : {
-                      weekKey: null,
-                      weekStandings: createEmptyWeekStandings(),
-                    }),
               });
 
               return EMPTY;

--- a/apps/client/src/app/shared/services/http/fixtures.service.ts
+++ b/apps/client/src/app/shared/services/http/fixtures.service.ts
@@ -1,7 +1,6 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
-import type { Observable } from 'rxjs';
-import { shareReplay } from 'rxjs';
+import { shareReplay, type Observable } from 'rxjs';
 
 import type { FixturesWeekData } from '@lib/models';
 import type { DateString } from '@lib/shared';
@@ -19,7 +18,8 @@ export class AbstractedHttpWeekFixturesService extends HttpWeekFixturesService {
   http = inject(HttpClient);
 
   getWeekFixtures(date: DateString): Observable<FixturesWeekData> {
-    const params = new HttpParams().set('date', date);
+    const params = new HttpParams().set('date', date).set('withEdgeDays', true);
+
     return this.http
       .get<FixturesWeekData>(this.BASE_URL + '/by-date', {
         params,

--- a/apps/client/src/app/shared/services/http/standings.service.ts
+++ b/apps/client/src/app/shared/services/http/standings.service.ts
@@ -1,7 +1,6 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
-import type { Observable } from 'rxjs';
-import { shareReplay } from 'rxjs';
+import { shareReplay, type Observable } from 'rxjs';
 
 import type {
   CompetitionId,
@@ -42,7 +41,10 @@ export class AbstractedHttpStandingsService extends HttpStandingsService {
 
   getWeekStandings(date: DateString): Observable<StandingsWeekData> {
     const dateString = date.substring(0, 10);
-    const params = new HttpParams().append('date', dateString);
+    const params = new HttpParams()
+      .append('date', dateString)
+      .append('withEdgeDays', true);
+
     return this.http
       .get<StandingsWeekData>(this.BASE_URL + '/start-top-five', {
         params,

--- a/lib/shared/helper/date.helper.ts
+++ b/lib/shared/helper/date.helper.ts
@@ -70,3 +70,26 @@ export const formatFixtureTime = (
 
   return FIXTURE_TIME_FORMATTER.format(date);
 };
+
+export const getWeekStartFromKey = (weekKey: string): DateString => {
+  const match = /^(\d{4})-W(\d{2})$/.exec(weekKey);
+
+  if (!match) {
+    throw new Error(`Invalid calendar week key: ${weekKey}`);
+  }
+
+  const [, year, week] = match;
+
+  return moment
+    .tz(TIMEZONE)
+    .isoWeekYear(Number(year))
+    .isoWeek(Number(week))
+    .startOf('isoWeek')
+    .format('YYYY-MM-DD');
+};
+
+export const addDays = (date: DateString, days: number): DateString =>
+  moment
+    .tz(date, 'YYYY-MM-DD', TIMEZONE)
+    .add(days, 'days')
+    .format('YYYY-MM-DD');


### PR DESCRIPTION
- fetch fixture and standings week data with edge days API already implemented
- keep previous Sunday / next Monday data visible while switching weeks
- map 9-day API responses to the 7 visible overview days
- preserve existing week data while loading or when a new week request fails
- add edge-day availability and loading-state tests
- fix week toggle tracking by reusing weekday positions via $index