### PR TITLE
refactor(shared): centralize two-legged rounds data

### DIFF
--- a/apps/client/src/app/shared/components/fixture-list/components/fixture-list-item/fixture-list-item.facade.ts
+++ b/apps/client/src/app/shared/components/fixture-list/components/fixture-list-item/fixture-list-item.facade.ts
@@ -1,17 +1,13 @@
 import { Injectable } from '@angular/core';
 
-import type {
-  CompetitionId,
-  CompetitionRound,
-  ExtendedFixtureDTO,
-} from '@lib/models';
 import {
+  type ExtendedFixtureDTO,
   STATUS_TYPES_FINISHED,
   STATUS_TYPES_PLAYING,
   STATUS_TYPES_SCHEDULED,
   STATUS_VALUE_HALFTIME,
 } from '@lib/models';
-import { COMPETITION_ID } from '@lib/shared';
+import { COMPETITION_KO_ROUNDS, isTwoLeggedRound } from '@lib/shared';
 
 @Injectable()
 export class FixtureListItemFacade {
@@ -19,42 +15,6 @@ export class FixtureListItemFacade {
   readonly halfTime = [STATUS_VALUE_HALFTIME];
   readonly playing = [...STATUS_TYPES_PLAYING];
   readonly finished = [...STATUS_TYPES_FINISHED];
-
-  readonly twoLeggedCompetitions: { [key: CompetitionId]: CompetitionRound[] } =
-    {
-      [COMPETITION_ID.EUROPA_UEFA_CHAMPIONS_LEAGUE]: [
-        'Round of 16',
-        'Quarter-finals',
-        'Semi-finals',
-      ],
-      [COMPETITION_ID.EUROPA_UEFA_EURO_LEAGUE]: [
-        'Round of 16',
-        'Quarter-finals',
-        'Semi-finals',
-      ],
-      [COMPETITION_ID.INTERNATIONAL_UEFA_NATIONS_LEAGUE]: [
-        'Play-offs A/B',
-        'Play-offs B/C',
-        'Quarter-finals',
-        'Play-offs C/D',
-      ],
-      [COMPETITION_ID.ENGLAND_LEAGUE_CUP]: ['Semi-finals'],
-      [COMPETITION_ID.ITALY_COPPA_ITALIA]: ['Semi-finals'],
-      [COMPETITION_ID.SPAIN_COPA_DEL_REY]: ['Semi-finals'],
-    };
-
-  readonly koRounds = [
-    'Preliminary Round',
-    'Play-offs',
-    '1st Round',
-    '2nd Round',
-    '3rd Round',
-    'Round of 32',
-    'Round of 16',
-    'Quarter-finals',
-    'Semi-finals',
-    'Final',
-  ];
 
   isTeamEliminated(
     fixture: ExtendedFixtureDTO,
@@ -77,13 +37,11 @@ export class FixtureListItemFacade {
   ): boolean => {
     const round = fixture.league.round;
 
-    const isKoRound = this.koRounds.includes(round);
-    if (!isKoRound) return false;
+    if (!COMPETITION_KO_ROUNDS.includes(round)) {
+      return false;
+    }
 
-    const isTwoLeggedCompetition = this.isTwoLeggedCompetition(fixture);
-    const isTwoLeggedRound = this.getTwoLeggedRounds(fixture).includes(round);
-
-    if (isTwoLeggedCompetition && isTwoLeggedRound) {
+    if (isTwoLeggedRound(fixture.league.id, fixture.league.round)) {
       return false;
     }
 
@@ -94,31 +52,16 @@ export class FixtureListItemFacade {
     fixture: ExtendedFixtureDTO,
     team: 'home' | 'away'
   ): boolean => {
-    const round = fixture.league.round;
-    const isTwoLeggedCompetition = this.isTwoLeggedCompetition(fixture);
-    const isTwoLeggedRound = this.getTwoLeggedRounds(fixture).includes(round);
+    if (!isTwoLeggedRound(fixture.league.id, fixture.league.round)) {
+      return false;
+    }
 
-    const hasFinalData = 'final' in fixture;
-    const winnerOfFinal = fixture?.final?.winnerOfFinal;
-    const winnerTeamId = hasFinalData ? winnerOfFinal : null;
-    const isFinalFinished = !!winnerTeamId;
-    const relatedTeam = fixture.teams[team].id;
+    const winnerTeamId = fixture.final?.winnerOfFinal;
 
-    return (
-      isTwoLeggedCompetition &&
-      isTwoLeggedRound &&
-      isFinalFinished &&
-      relatedTeam !== winnerTeamId
-    );
-  };
+    if (!winnerTeamId) {
+      return false;
+    }
 
-  private getTwoLeggedRounds = (
-    fixture: ExtendedFixtureDTO
-  ): CompetitionRound[] => {
-    return this.twoLeggedCompetitions[fixture.league.id] || [];
-  };
-
-  private isTwoLeggedCompetition = (fixture: ExtendedFixtureDTO): boolean => {
-    return fixture.league.id in this.twoLeggedCompetitions;
+    return fixture.teams[team].id !== winnerTeamId;
   };
 }

--- a/lib/shared/constants/rounds.data.ts
+++ b/lib/shared/constants/rounds.data.ts
@@ -1,4 +1,9 @@
+import {
+  CompetitionId,
+  CompetitionRound,
+} from '../../models/competition.model';
 import { buildCompetitionRounds } from '../helper/rounds.helper';
+import { COMPETITION_ID } from './competition/id.constant';
 
 const REGULAR_SEASON_STR = 'Regular Season - ';
 const GROUP_STAGE_STR = 'Group Stage - ';
@@ -822,3 +827,47 @@ export const COMPETITION_ROUNDS = buildCompetitionRounds({
     2026: MLS_2026,
   },
 });
+
+export const TWO_LEGGED_COMPETITION_ROUNDS: Partial<
+  Record<CompetitionId, readonly CompetitionRound[]>
+> = {
+  [COMPETITION_ID.EUROPA_UEFA_CHAMPIONS_LEAGUE]: [
+    '1st Qualifying Round',
+    '2nd Qualifying Round',
+    '3rd Qualifying Round',
+    'Play-offs',
+    'Round of 16',
+    'Quarter-finals',
+    'Semi-finals',
+  ],
+  [COMPETITION_ID.EUROPA_UEFA_EURO_LEAGUE]: [
+    '1st Qualifying Round',
+    '2nd Qualifying Round',
+    '3rd Qualifying Round',
+    'Play-offs',
+    'Round of 16',
+    'Quarter-finals',
+    'Semi-finals',
+  ],
+  [COMPETITION_ID.INTERNATIONAL_UEFA_NATIONS_LEAGUE]: [
+    'Play-offs A/B',
+    'Play-offs B/C',
+    'Quarter-finals',
+    'Play-offs C/D',
+  ],
+  [COMPETITION_ID.ENGLAND_LEAGUE_CUP]: ['Semi-finals'],
+  [COMPETITION_ID.ITALY_COPPA_ITALIA]: ['Semi-finals'],
+  [COMPETITION_ID.SPAIN_COPA_DEL_REY]: ['Semi-finals'],
+};
+
+export const COMPETITION_KO_ROUNDS = [
+  'Preliminary Round',
+  '1st Round',
+  '2nd Round',
+  '3rd Round',
+  'Round of 32',
+  'Round of 16',
+  'Quarter-finals',
+  'Semi-finals',
+  'Final',
+];

--- a/lib/shared/helper/rounds.helper.ts
+++ b/lib/shared/helper/rounds.helper.ts
@@ -1,10 +1,11 @@
-import {
-  type CompetitionId,
-  type CompetitionRounds,
-  type CompetitionRoundsData,
-  type CompetitionSeason,
+import type {
+  CompetitionId,
+  CompetitionRound,
+  CompetitionRounds,
+  CompetitionRoundsData,
+  CompetitionSeason,
 } from '../../models/competition.model';
-
+import { TWO_LEGGED_COMPETITION_ROUNDS } from '../constants/rounds.data';
 import { SEASONS } from '../constants/season.data';
 
 export const buildCompetitionRounds = (
@@ -32,4 +33,11 @@ export const buildCompetitionRounds = (
   }
 
   return result;
+};
+
+export const isTwoLeggedRound = (
+  competitionId: CompetitionId,
+  round: CompetitionRound
+): boolean => {
+  return TWO_LEGGED_COMPETITION_ROUNDS[competitionId]?.includes(round) ?? false;
 };


### PR DESCRIPTION
- centralize two-legged competition rounds in the shared lib and reuse them in both reelscore projects
- add a shared helper to detect two-legged competition rounds
- simplify findFirstLeg() to query the exact league instead of all two-legged competition IDs