### PR TITLE
fix(overview): optimize day switch rendering

### DIFF
--- a/apps/client/src/app/features/overview/components/content/content.facade.spec.ts
+++ b/apps/client/src/app/features/overview/components/content/content.facade.spec.ts
@@ -23,7 +23,6 @@ describe('OverviewContentFacade', () => {
   const initialDate: DateString = '2026-08-10';
   const sameWeekDate: DateString = '2026-08-12';
 
-  const previousSunday: DateString = '2026-08-09';
   const currentSunday: DateString = '2026-08-16';
   const nextMonday: DateString = '2026-08-17';
   const nextTuesday: DateString = '2026-08-18';
@@ -99,88 +98,98 @@ describe('OverviewContentFacade', () => {
     });
   });
 
-  it('should load fixtures and standings for the selected week', () => {
-    TestBed.inject(OverviewContentFacade);
-    TestBed.tick();
+  describe('week loading', () => {
+    it('should load fixtures and standings for the selected week', () => {
+      TestBed.inject(OverviewContentFacade);
+      TestBed.tick();
 
-    expect(fixturesStoreMock.loadWeekFixtures).toHaveBeenCalledWith(
-      initialDate
-    );
-    expect(standingsStoreMock.loadWeekStandings).toHaveBeenCalledWith(
-      initialDate
-    );
+      expect(fixturesStoreMock.loadWeekFixtures).toHaveBeenCalledWith(
+        initialDate
+      );
+      expect(standingsStoreMock.loadWeekStandings).toHaveBeenCalledWith(
+        initialDate
+      );
+    });
+
+    it('should not reload the week when selected day changes within the same week', () => {
+      TestBed.inject(OverviewContentFacade);
+      TestBed.tick();
+
+      markWeekAsCached(initialDate);
+
+      fixturesStoreMock.loadWeekFixtures.mockClear();
+      standingsStoreMock.loadWeekStandings.mockClear();
+
+      selectedDay.set(sameWeekDate);
+      TestBed.tick();
+
+      expect(fixturesStoreMock.loadWeekFixtures).not.toHaveBeenCalled();
+      expect(standingsStoreMock.loadWeekStandings).not.toHaveBeenCalled();
+    });
+
+    it('should reload fixtures and standings when selected day changes to another week', () => {
+      TestBed.inject(OverviewContentFacade);
+      TestBed.tick();
+
+      markWeekAsCached(initialDate);
+
+      fixturesStoreMock.loadWeekFixtures.mockClear();
+      standingsStoreMock.loadWeekStandings.mockClear();
+
+      selectedDay.set(nextMonday);
+      TestBed.tick();
+
+      expect(fixturesStoreMock.loadWeekFixtures).toHaveBeenCalledWith(
+        nextMonday
+      );
+      expect(standingsStoreMock.loadWeekStandings).toHaveBeenCalledWith(
+        nextMonday
+      );
+    });
+
+    it('should not load when the selected week is already cached', () => {
+      markWeekAsCached(initialDate);
+
+      TestBed.inject(OverviewContentFacade);
+      TestBed.tick();
+
+      expect(fixturesStoreMock.loadWeekFixtures).not.toHaveBeenCalled();
+      expect(standingsStoreMock.loadWeekStandings).not.toHaveBeenCalled();
+    });
   });
 
-  it('should not reload the week when selected day changes within the same week', () => {
-    TestBed.inject(OverviewContentFacade);
-    TestBed.tick();
+  describe('request state', () => {
+    it('should expose fixtures and standings loading states independently', () => {
+      const facade = TestBed.inject(OverviewContentFacade);
+      TestBed.tick();
 
-    markWeekAsCached(initialDate);
+      fixturesStoreMock.isLoading.set(true);
 
-    fixturesStoreMock.loadWeekFixtures.mockClear();
-    standingsStoreMock.loadWeekStandings.mockClear();
+      expect(facade.fixturesLoading()).toBe(true);
+      expect(facade.standingsLoading()).toBe(false);
 
-    selectedDay.set(sameWeekDate);
-    TestBed.tick();
+      fixturesStoreMock.isLoading.set(false);
+      standingsStoreMock.isLoading.set(true);
 
-    expect(fixturesStoreMock.loadWeekFixtures).not.toHaveBeenCalled();
-    expect(standingsStoreMock.loadWeekStandings).not.toHaveBeenCalled();
-  });
+      expect(facade.fixturesLoading()).toBe(false);
+      expect(facade.standingsLoading()).toBe(true);
+    });
 
-  it('should reload fixtures and standings when selected day changes to another week', () => {
-    TestBed.inject(OverviewContentFacade);
-    TestBed.tick();
+    it('should expose fixtures and standings errors independently', () => {
+      const facade = TestBed.inject(OverviewContentFacade);
+      TestBed.tick();
 
-    markWeekAsCached(initialDate);
+      fixturesStoreMock.error.set('Fixtures failed');
 
-    fixturesStoreMock.loadWeekFixtures.mockClear();
-    standingsStoreMock.loadWeekStandings.mockClear();
+      expect(facade.fixturesError()).toBe('Fixtures failed');
+      expect(facade.standingsError()).toBeNull();
 
-    selectedDay.set(nextMonday);
-    TestBed.tick();
+      fixturesStoreMock.error.set(null);
+      standingsStoreMock.error.set('Standings failed');
 
-    expect(fixturesStoreMock.loadWeekFixtures).toHaveBeenCalledWith(nextMonday);
-    expect(standingsStoreMock.loadWeekStandings).toHaveBeenCalledWith(
-      nextMonday
-    );
-  });
-
-  it('should not load when the selected week is already cached', () => {
-    markWeekAsCached(initialDate);
-
-    TestBed.inject(OverviewContentFacade);
-    TestBed.tick();
-
-    expect(fixturesStoreMock.loadWeekFixtures).not.toHaveBeenCalled();
-    expect(standingsStoreMock.loadWeekStandings).not.toHaveBeenCalled();
-  });
-
-  it('should expose fixture and standings loading states independently', () => {
-    const facade = TestBed.inject(OverviewContentFacade);
-    TestBed.tick();
-
-    fixturesStoreMock.isLoading.set(true);
-    standingsStoreMock.isLoading.set(false);
-
-    expect(facade.fixturesLoading()).toBe(true);
-    expect(facade.standingsLoading()).toBe(false);
-
-    fixturesStoreMock.isLoading.set(false);
-    standingsStoreMock.isLoading.set(true);
-
-    expect(facade.fixturesLoading()).toBe(false);
-    expect(facade.standingsLoading()).toBe(true);
-  });
-
-  it('should expose fixture and standings errors independently', () => {
-    const facade = TestBed.inject(OverviewContentFacade);
-    TestBed.tick();
-
-    fixturesStoreMock.error.set('Fixtures failed');
-    standingsStoreMock.error.set(null);
-
-    expect(facade.fixturesError()).toEqual('Fixtures failed');
-    expect(facade.standingsError()).toBeNull();
+      expect(facade.fixturesError()).toBeNull();
+      expect(facade.standingsError()).toBe('Standings failed');
+    });
   });
 
   describe('week data mapping', () => {
@@ -194,7 +203,7 @@ describe('OverviewContentFacade', () => {
       expect(facade.hasFixturesDataForSelectedDay()).toBe(false);
     });
 
-    it('should map the nine loaded fixture days to the seven visible weekdays', () => {
+    it('should map the nine loaded fixtures days to the seven visible weekdays', () => {
       const weekData = createIndexedFixturesWeekData();
 
       fixturesStoreMock.weekFixtures.set(weekData);
@@ -205,6 +214,40 @@ describe('OverviewContentFacade', () => {
 
       expect(facade.weekFixtures()).toEqual(weekData.slice(1, 8));
       expect(facade.hasFixturesDataForSelectedDay()).toBe(true);
+    });
+
+    it('should keep the visible fixtures week data reference when selected day changes within the same week', () => {
+      const weekData = createIndexedFixturesWeekData();
+
+      fixturesStoreMock.weekFixtures.set(weekData);
+      markWeekAsCached(initialDate);
+
+      const facade = TestBed.inject(OverviewContentFacade);
+      TestBed.tick();
+
+      const weekFixtures = facade.weekFixtures();
+
+      selectedDay.set(sameWeekDate);
+      TestBed.tick();
+
+      expect(facade.weekFixtures()).toBe(weekFixtures);
+    });
+
+    it('should keep the visible standings week data reference when selected day changes within the same week', () => {
+      const weekData = createIndexedStandingsWeekData();
+
+      standingsStoreMock.weekStandings.set(weekData);
+      markWeekAsCached(initialDate);
+
+      const facade = TestBed.inject(OverviewContentFacade);
+      TestBed.tick();
+
+      const weekStandings = facade.weekStandings();
+
+      selectedDay.set(sameWeekDate);
+      TestBed.tick();
+
+      expect(facade.weekStandings()).toBe(weekStandings);
     });
 
     it('should keep the edge monday visible while the next week is loading', () => {
@@ -294,59 +337,6 @@ describe('OverviewContentFacade', () => {
       expect(facade.weekFixtures()[1]).toBeUndefined();
       expect(facade.hasFixturesDataForSelectedDay()).toBe(false);
     });
-  });
-
-  describe('edge-day availability', () => {
-    it('should report fixture data as available for the previous sunday edge day', () => {
-      fixturesStoreMock.weekKey.set(formatCalendarWeekKey(initialDate));
-
-      const facade = TestBed.inject(OverviewContentFacade);
-      TestBed.tick();
-
-      selectedDay.set(previousSunday);
-
-      expect(facade.hasFixturesDataForSelectedDay()).toBe(true);
-    });
-
-    it('should report fixture data as available for the next monday edge day', () => {
-      fixturesStoreMock.weekKey.set(formatCalendarWeekKey(initialDate));
-
-      const facade = TestBed.inject(OverviewContentFacade);
-      TestBed.tick();
-
-      selectedDay.set(nextMonday);
-
-      expect(facade.hasFixturesDataForSelectedDay()).toBe(true);
-    });
-
-    it('should report fixture and standings data as unavailable for a non-edge day of another week', () => {
-      const cachedWeekKey = formatCalendarWeekKey(initialDate);
-
-      fixturesStoreMock.weekKey.set(cachedWeekKey);
-      standingsStoreMock.weekKey.set(cachedWeekKey);
-
-      const facade = TestBed.inject(OverviewContentFacade);
-      TestBed.tick();
-
-      selectedDay.set(nextTuesday);
-      TestBed.tick();
-
-      expect(facade.hasFixturesDataForSelectedDay()).toBe(false);
-      expect(facade.hasStandingsDataForSelectedDay()).toBe(false);
-    });
-
-    it('should report fixture data as unavailable before the previous sunday', () => {
-      const dateBeforeEdgeRange: DateString = '2026-08-08';
-
-      fixturesStoreMock.weekKey.set(formatCalendarWeekKey(initialDate));
-
-      const facade = TestBed.inject(OverviewContentFacade);
-      TestBed.tick();
-
-      selectedDay.set(dateBeforeEdgeRange);
-
-      expect(facade.hasFixturesDataForSelectedDay()).toBe(false);
-    });
 
     it('should keep standings edge-day data available while the next week is loading', () => {
       const weekData = createIndexedStandingsWeekData();
@@ -365,6 +355,37 @@ describe('OverviewContentFacade', () => {
 
       expect(facade.weekStandings()[0]).toBe(weekData[8]);
       expect(facade.hasStandingsDataForSelectedDay()).toBe(true);
+    });
+  });
+
+  describe('data availability', () => {
+    it('should report fixtures and standings data as unavailable for a non-edge day of another week', () => {
+      const cachedWeekKey = formatCalendarWeekKey(initialDate);
+
+      fixturesStoreMock.weekKey.set(cachedWeekKey);
+      standingsStoreMock.weekKey.set(cachedWeekKey);
+
+      const facade = TestBed.inject(OverviewContentFacade);
+      TestBed.tick();
+
+      selectedDay.set(nextTuesday);
+      TestBed.tick();
+
+      expect(facade.hasFixturesDataForSelectedDay()).toBe(false);
+      expect(facade.hasStandingsDataForSelectedDay()).toBe(false);
+    });
+
+    it('should report fixtures data as unavailable before the previous sunday', () => {
+      const dateBeforeEdgeRange: DateString = '2026-08-08';
+
+      fixturesStoreMock.weekKey.set(formatCalendarWeekKey(initialDate));
+
+      const facade = TestBed.inject(OverviewContentFacade);
+      TestBed.tick();
+
+      selectedDay.set(dateBeforeEdgeRange);
+
+      expect(facade.hasFixturesDataForSelectedDay()).toBe(false);
     });
   });
 

--- a/apps/client/src/app/features/overview/components/content/content.facade.ts
+++ b/apps/client/src/app/features/overview/components/content/content.facade.ts
@@ -19,6 +19,12 @@ const UI_WEEK_FIRST_INDEX = 0;
 const UI_WEEK_LAST_INDEX = 6;
 const UI_DAYS_PER_WEEK = 7;
 
+type VisibleWeekMode =
+  | 'current'
+  | 'previous-edge'
+  | 'next-edge'
+  | 'unavailable';
+
 @Injectable()
 export class OverviewContentFacade {
   readonly weekdays = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'];
@@ -45,34 +51,44 @@ export class OverviewContentFacade {
     formatCalendarWeekKey(this.selectedDateString())
   );
 
+  private readonly fixturesVisibleWeekMode = computed(() =>
+    getVisibleWeekMode(
+      this.weekFixturesStore.weekKey(),
+      this.selectedDateString()
+    )
+  );
+
+  private readonly standingsVisibleWeekMode = computed(() =>
+    getVisibleWeekMode(
+      this.weekStandingsStore.weekKey(),
+      this.selectedDateString()
+    )
+  );
+
   readonly weekFixtures = computed(() =>
     getVisibleWeekData(
       this.weekFixturesStore.weekFixtures(),
-      this.weekFixturesStore.weekKey(),
-      this.selectedDateString()
+      this.fixturesVisibleWeekMode()
     )
   );
 
   readonly weekStandings = computed(() =>
     getVisibleWeekData(
       this.weekStandingsStore.weekStandings(),
-      this.weekStandingsStore.weekKey(),
-      this.selectedDateString()
+      this.standingsVisibleWeekMode()
     )
   );
 
-  readonly hasFixturesDataForSelectedDay = computed(() =>
-    hasDataForSelectedDay(
-      this.weekFixturesStore.weekKey(),
-      this.selectedDateString()
-    )
+  readonly hasFixturesDataForSelectedDay = computed(
+    () =>
+      this.weekFixturesStore.weekKey() !== null &&
+      this.fixturesVisibleWeekMode() !== 'unavailable'
   );
 
-  readonly hasStandingsDataForSelectedDay = computed(() =>
-    hasDataForSelectedDay(
-      this.weekStandingsStore.weekKey(),
-      this.selectedDateString()
-    )
+  readonly hasStandingsDataForSelectedDay = computed(
+    () =>
+      this.weekStandingsStore.weekKey() !== null &&
+      this.standingsVisibleWeekMode() !== 'unavailable'
   );
 
   private readonly calendarWeekEffect = effect(() => {
@@ -95,32 +111,50 @@ export class OverviewContentFacade {
   });
 }
 
-function getVisibleWeekData<T>(
-  data: T[],
+function getVisibleWeekMode(
   cachedWeekKey: string | null,
   selectedDay: DateString
-): Array<T | undefined> {
+): VisibleWeekMode {
   if (
     cachedWeekKey === null ||
     cachedWeekKey === formatCalendarWeekKey(selectedDay)
   ) {
-    return data.slice(CURRENT_WEEK_START_INDEX, CURRENT_WEEK_END_INDEX + 1);
+    return 'current';
   }
 
-  const weekStart = getWeekStartFromKey(cachedWeekKey);
+  const cachedWeekStart = getWeekStartFromKey(cachedWeekKey);
 
-  if (selectedDay === addDays(weekStart, 7)) {
-    return createEdgeWeekData(UI_WEEK_FIRST_INDEX, data[EDGE_NEXT_DAY_INDEX]);
+  if (selectedDay === addDays(cachedWeekStart, 7)) {
+    return 'next-edge';
   }
 
-  if (selectedDay === addDays(weekStart, -1)) {
-    return createEdgeWeekData(
-      UI_WEEK_LAST_INDEX,
-      data[EDGE_PREVIOUS_DAY_INDEX]
-    );
+  if (selectedDay === addDays(cachedWeekStart, -1)) {
+    return 'previous-edge';
   }
 
-  return Array(UI_DAYS_PER_WEEK).fill(undefined);
+  return 'unavailable';
+}
+
+function getVisibleWeekData<T>(
+  data: T[],
+  mode: VisibleWeekMode
+): Array<T | undefined> {
+  switch (mode) {
+    case 'current':
+      return data.slice(CURRENT_WEEK_START_INDEX, CURRENT_WEEK_END_INDEX + 1);
+
+    case 'next-edge':
+      return createEdgeWeekData(UI_WEEK_FIRST_INDEX, data[EDGE_NEXT_DAY_INDEX]);
+
+    case 'previous-edge':
+      return createEdgeWeekData(
+        UI_WEEK_LAST_INDEX,
+        data[EDGE_PREVIOUS_DAY_INDEX]
+      );
+
+    case 'unavailable':
+      return Array(UI_DAYS_PER_WEEK).fill(undefined);
+  }
 }
 
 function createEdgeWeekData<T>(
@@ -131,24 +165,4 @@ function createEdgeWeekData<T>(
   weekData[index] = edgeDayData;
 
   return weekData;
-}
-
-function hasDataForSelectedDay(
-  cachedWeekKey: string | null,
-  selectedDay: DateString
-): boolean {
-  if (cachedWeekKey === null) {
-    return false;
-  }
-
-  if (cachedWeekKey === formatCalendarWeekKey(selectedDay)) {
-    return true;
-  }
-
-  const weekStart = getWeekStartFromKey(cachedWeekKey);
-
-  return (
-    selectedDay === addDays(weekStart, -1) ||
-    selectedDay === addDays(weekStart, 7)
-  );
 }

--- a/apps/client/src/app/features/overview/components/content/fixtures/fixtures.component.spec.ts
+++ b/apps/client/src/app/features/overview/components/content/fixtures/fixtures.component.spec.ts
@@ -21,12 +21,12 @@ class MatchDayListStubComponent {
 
 describe('OverviewFixturesComponent', () => {
   const facadeMock: {
-    initCompetitionsWithFixtures: jest.Mock<
+    groupFixturesByCompetition: jest.Mock<
       CompetitionWithFixtures[],
-      [ExtendedFixtureDTO[] | null]
+      [ExtendedFixtureDTO[]]
     >;
   } = {
-    initCompetitionsWithFixtures: jest.fn(),
+    groupFixturesByCompetition: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -51,7 +51,7 @@ describe('OverviewFixturesComponent', () => {
       .compileComponents();
 
     jest.clearAllMocks();
-    facadeMock.initCompetitionsWithFixtures.mockReturnValue([]);
+    facadeMock.groupFixturesByCompetition.mockReturnValue([]);
   });
 
   const createComponent = ({
@@ -127,7 +127,7 @@ describe('OverviewFixturesComponent', () => {
       fixtures: [EXAMPLE_FIXTURE],
     };
 
-    facadeMock.initCompetitionsWithFixtures.mockReturnValue([competition]);
+    facadeMock.groupFixturesByCompetition.mockReturnValue([competition]);
 
     const fixture = createComponent({
       fixtures: [EXAMPLE_FIXTURE],

--- a/apps/client/src/app/features/overview/components/content/fixtures/fixtures.component.ts
+++ b/apps/client/src/app/features/overview/components/content/fixtures/fixtures.component.ts
@@ -12,6 +12,8 @@ import type { ExtendedFixtureDTO } from '@lib/models';
 import { OverviewFixturesFacade } from './fixtures.facade';
 import { MatchDayListComponent } from './match-day-list.component';
 
+type FixturesViewState = 'loading' | 'error' | 'empty' | null;
+
 @Component({
   selector: 'rs-overview-fixtures',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -25,20 +27,18 @@ import { MatchDayListComponent } from './match-day-list.component';
   template: `
     <h2>Partien</h2>
 
-    @let comps = competitions(); @let fixtures = filteredFixtures(); @if (comps
-    && comps.length > 0) { @for (competition of comps; track competition.name) {
-    <rs-start-match-day-list
-      class="animate-fade-in"
-      [competition]="competition"
-    />
-    } } @else {
-    <p class="no-data">
-      @if (isLoading() && !hasDataForSelectedDay()) {
-      <span data-testid="fixtures-loading"> Spiele werden geladen ... </span>
-      } @else if (error()) { Fehler beim Laden der Spiele. } @else if
-      (fixtures.length === 0) { Es finden keine Spiele statt. }
+    @if (competitions().length > 0) { @for ( competition of competitions();
+    track getCompetitionKey(competition) ) {
+    <rs-start-match-day-list [competition]="competition" />
+    } } @else { @switch (viewState()) { @case ('loading') {
+    <p class="no-data" data-testid="fixtures-loading">
+      Spiele werden geladen ...
     </p>
-    }
+    } @case ('error') {
+    <p class="no-data">Fehler beim Laden der Spiele.</p>
+    } @case ('empty') {
+    <p class="no-data">Es finden keine Spiele statt.</p>
+    } } }
   `,
 })
 export class OverviewFixturesComponent {
@@ -49,7 +49,29 @@ export class OverviewFixturesComponent {
 
   private readonly facade = inject(OverviewFixturesFacade);
 
-  readonly competitions = computed<CompetitionWithFixtures[]>(() => {
-    return this.facade.initCompetitionsWithFixtures(this.filteredFixtures());
+  readonly competitions = computed<CompetitionWithFixtures[]>(() =>
+    this.facade.groupFixturesByCompetition(this.filteredFixtures())
+  );
+
+  readonly viewState = computed<FixturesViewState>(() => {
+    if (this.isLoading() && !this.hasDataForSelectedDay()) {
+      return 'loading';
+    }
+
+    if (this.error()) {
+      return 'error';
+    }
+
+    if (this.filteredFixtures().length === 0) {
+      return 'empty';
+    }
+
+    return null;
   });
+
+  getCompetitionKey(competition: CompetitionWithFixtures): string {
+    const round = competition.fixtures[0].league.round;
+
+    return `${competition.id}-${round}`;
+  }
 }

--- a/apps/client/src/app/features/overview/components/content/fixtures/fixtures.facade.spec.ts
+++ b/apps/client/src/app/features/overview/components/content/fixtures/fixtures.facade.spec.ts
@@ -39,7 +39,7 @@ describe('OverviewFixturesFacade', () => {
   });
 
   it('should return fixtures from all competitions when no competition filter is selected', () => {
-    const competitions = facade.initCompetitionsWithFixtures(fixtures);
+    const competitions = facade.groupFixturesByCompetition(fixtures);
 
     expect(competitions).toHaveLength(2);
 
@@ -51,7 +51,7 @@ describe('OverviewFixturesFacade', () => {
   it('should return only fixtures from the selected competition', () => {
     filterService.selectedCompetition.set(78);
 
-    const competitions = facade.initCompetitionsWithFixtures(fixtures);
+    const competitions = facade.groupFixturesByCompetition(fixtures);
 
     expect(competitions).toHaveLength(1);
     expect(competitions[0].id).toBe(78);
@@ -61,11 +61,11 @@ describe('OverviewFixturesFacade', () => {
   it('should restore fixtures from all competitions after clearing the filter', () => {
     filterService.selectedCompetition.set(78);
 
-    expect(facade.initCompetitionsWithFixtures(fixtures)).toHaveLength(1);
+    expect(facade.groupFixturesByCompetition(fixtures)).toHaveLength(1);
 
     filterService.selectedCompetition.set(null);
 
-    const competitions = facade.initCompetitionsWithFixtures(fixtures);
+    const competitions = facade.groupFixturesByCompetition(fixtures);
 
     expect(competitions).toHaveLength(2);
 
@@ -83,7 +83,7 @@ describe('OverviewFixturesFacade', () => {
       },
     };
 
-    const competitions = facade.initCompetitionsWithFixtures([
+    const competitions = facade.groupFixturesByCompetition([
       CHAMPIONS_LEAGUE_FIXTURE,
       secondChampionsLeagueFixture,
     ]);
@@ -105,7 +105,7 @@ describe('OverviewFixturesFacade', () => {
       },
     };
 
-    const competitions = facade.initCompetitionsWithFixtures([
+    const competitions = facade.groupFixturesByCompetition([
       CHAMPIONS_LEAGUE_FIXTURE,
       semiFinalFixture,
     ]);

--- a/apps/client/src/app/features/overview/components/content/fixtures/fixtures.facade.ts
+++ b/apps/client/src/app/features/overview/components/content/fixtures/fixtures.facade.ts
@@ -5,84 +5,78 @@ import {
   SELECT_COMPETITION_DATA_FLAT,
   type CompetitionWithFixtures,
 } from '@app/shared';
-import type { CompetitionName, ExtendedFixtureDTO } from '@lib/models';
+import type { ExtendedFixtureDTO } from '@lib/models';
 
 import { FilterService } from '../../../services';
 
+const COMPETITION_BY_ID = new Map(
+  SELECT_COMPETITION_DATA_FLAT.map((competition) => [
+    competition.id,
+    competition,
+  ])
+);
+
+const DEFAULT_COMPETITION_ORDER = Object.keys(COMPETITIONS_ORDER).length + 1;
+
 @Injectable()
 export class OverviewFixturesFacade {
-  private filterService = inject(FilterService);
+  private readonly filterService = inject(FilterService);
 
-  initCompetitionsWithFixtures = (
-    fixtures: Array<ExtendedFixtureDTO> | null
-  ): Array<CompetitionWithFixtures> => {
-    if (!fixtures) return [];
+  groupFixturesByCompetition(
+    fixtures: ExtendedFixtureDTO[]
+  ): CompetitionWithFixtures[] {
+    const selectedCompetition = this.filterService.selectedCompetition();
+    const groups = new Map<string, CompetitionWithFixtures>();
 
-    const competitionGroups = [
-      ...new Map(
-        fixtures.map((fixture) => [
-          this.getCompetitionGroupKey(fixture),
-          {
-            id: fixture.league.id,
-            name: fixture.league.name,
-            round: fixture.league.round,
-          },
-        ])
-      ).values(),
-    ];
+    for (const fixture of fixtures) {
+      if (
+        selectedCompetition !== null &&
+        fixture.league.id !== selectedCompetition
+      ) {
+        continue;
+      }
 
-    const competitions: Array<CompetitionWithFixtures> = competitionGroups
-      .map((group) =>
-        this.groupFixturesToCompetitions(
-          fixtures,
-          group.id,
-          group.name,
-          group.round
-        )
-      )
-      .sort((a, b) => {
-        const ORDER = COMPETITIONS_ORDER;
-        const endOfList = Object.keys(ORDER).length + 1;
+      const key = this.getCompetitionGroupKey(fixture);
+      const existingGroup = groups.get(key);
 
-        return (ORDER[a.name] || endOfList) - (ORDER[b.name] || endOfList);
-      });
+      if (existingGroup) {
+        existingGroup.fixtures.push(fixture);
+        continue;
+      }
 
-    const filter = this.filterService.selectedCompetition();
-    const filtered = competitions.filter((c) => c.id === filter);
+      groups.set(key, this.createCompetitionGroup(fixture));
+    }
 
-    return filter ? filtered : competitions;
-  };
-
-  private groupFixturesToCompetitions = (
-    filteredFixtures: ExtendedFixtureDTO[],
-    id: number,
-    name: CompetitionName,
-    round?: string
-  ): CompetitionWithFixtures => {
-    const fixture = filteredFixtures.find(
-      (f) => f.league.id === id && f.league.round === round
+    return [...groups.values()].sort(
+      (a, b) => this.getCompetitionOrder(a) - this.getCompetitionOrder(b)
     );
+  }
 
-    const competition = SELECT_COMPETITION_DATA_FLAT.find(
-      (c) => c.id === fixture?.league.id
-    );
+  private createCompetitionGroup(
+    fixture: ExtendedFixtureDTO
+  ): CompetitionWithFixtures {
+    const competition = COMPETITION_BY_ID.get(fixture.league.id);
 
-    if (!fixture || !competition) {
-      throw new Error(`Not found ('${name}'${round ? ` - ${round}` : ''})`);
+    if (!competition) {
+      const round = fixture.league.round ? ` - ${fixture.league.round}` : '';
+
+      throw new Error(`Not found ('${fixture.league.name}${round}')`);
     }
 
     return {
-      name,
+      id: fixture.league.id,
+      name: fixture.league.name,
+      image: fixture.league.flag ?? 'error',
       url: ['/', 'competition', competition.url],
-      id: fixture.league.id || -1,
-      image: fixture.league.flag || 'error',
-      fixtures: filteredFixtures.filter(
-        (f) => f.league.id === id && f.league.round === round
-      ),
+      fixtures: [fixture],
     };
-  };
+  }
 
-  private getCompetitionGroupKey = (fixture: ExtendedFixtureDTO): string => {
+  private getCompetitionOrder(competition: CompetitionWithFixtures): number {
+    return COMPETITIONS_ORDER[competition.name] ?? DEFAULT_COMPETITION_ORDER;
+  }
+
+  private getCompetitionGroupKey(fixture: ExtendedFixtureDTO): string {
     return `${fixture.league.id}-${fixture.league.round ?? 'default'}`;
-  };
+  }
 }

--- a/apps/client/src/app/features/overview/components/content/fixtures/match-day-list.component.ts
+++ b/apps/client/src/app/features/overview/components/content/fixtures/match-day-list.component.ts
@@ -4,7 +4,6 @@ import {
   computed,
   inject,
   input,
-  untracked,
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
@@ -93,16 +92,16 @@ export class MatchDayListComponent {
   private readonly themeService = inject(ThemeService);
 
   private readonly firstFixture = computed(
-    () => untracked(this.competition).fixtures[0]
+    () => this.competition().fixtures[0]
   );
 
   readonly round = computed<CompetitionRound>(() => {
-    const fixture = untracked(this.firstFixture);
-    return fixture ? fixture.league.round : '';
+    return this.firstFixture()?.league.round ?? '?';
   });
 
   readonly getCompetitionLogo = computed(() => {
-    const fixture = untracked(this.firstFixture);
+    const fixture = this.firstFixture();
+
     return getCompetitionLogo(
       fixture.league.id,
       24,
@@ -112,7 +111,8 @@ export class MatchDayListComponent {
   });
 
   readonly getCompetitionLogoSet = computed(() => {
-    const fixture = untracked(this.firstFixture);
+    const fixture = this.firstFixture();
+
     return getCompetitionLogoSrcSet(
       fixture.league.id,
       24,

--- a/apps/client/src/app/features/overview/components/content/standings/standings.component.ts
+++ b/apps/client/src/app/features/overview/components/content/standings/standings.component.ts
@@ -32,34 +32,30 @@ import { OverviewStandingsFacade } from './standings.facade';
     (isFiltering() && filteredStandings) { @if (hasMultipleGroups()) { @for (
     multipleStanding of filteredStandings.league.standings; track $index ) {
     <rs-standings-table
-      class="animate-fade-in"
       [ranks]="multipleStanding"
       [league]="filteredStandings.league"
     />
     } } @else {
     <rs-standings-table
-      class="animate-fade-in"
       [ranks]="filteredStandings.league.standings![0]"
       [league]="filteredStandings.league"
     />
 
     @if (showHomeAndAwayStandings()) {
     <rs-standings-table
-      class="animate-fade-in"
       [ranks]="filteredStandings.league.standings![1]"
       [league]="filteredStandings.league"
       header="Heimtabelle"
     />
 
     <rs-standings-table
-      class="animate-fade-in"
       [ranks]="filteredStandings.league.standings![2]"
       [league]="filteredStandings.league"
       header="Auswärtstabelle"
     />
-    } } } @else if (showTopFive()) { @for (standing of ws; track $index) {
+    } } } @else if (showTopFive()) { @for (standing of ws; track
+    standing.league.id) {
     <rs-standings-table
-      class="animate-fade-in"
       [ranks]="standing.league.standings![0]"
       [league]="standing.league"
     />

--- a/apps/client/src/app/features/overview/components/date-bar/date-bar.component.ts
+++ b/apps/client/src/app/features/overview/components/date-bar/date-bar.component.ts
@@ -52,7 +52,6 @@ import { WeekToggleGroupComponent } from './week-toggle-group.component';
     <rs-week-toggle-group
       [weekdays]="weekdays()"
       [selectedDay]="selectedDay()"
-      [calendarWeek]="calendarWeek()"
       [isLoading]="isLoading()"
       (dateSelected)="setDate($event)"
     ></rs-week-toggle-group>
@@ -79,7 +78,6 @@ export class DateBarComponent {
   readonly selectedDay = this.selectedDateService.selectedDay;
   readonly weekdays = this.dateNavigationService.weekdays;
   readonly isToday = this.dateNavigationService.isToday;
-  readonly calendarWeek = this.dateNavigationService.calendarWeek;
 
   readonly isLoading = computed<boolean>(
     () => this.weekFixtures.isLoading() || this.weekStandings.isLoading()

--- a/apps/client/src/app/features/overview/components/date-bar/week-toggle-group.component.spec.ts
+++ b/apps/client/src/app/features/overview/components/date-bar/week-toggle-group.component.spec.ts
@@ -39,7 +39,6 @@ describe('WeekToggleGroupComponent', () => {
     const fixture = TestBed.createComponent(WeekToggleGroupComponent);
 
     fixture.componentRef.setInput('selectedDay', selectedDay);
-    fixture.componentRef.setInput('calendarWeek', 33);
     fixture.componentRef.setInput('weekdays', weekdays);
     fixture.componentRef.setInput('isLoading', false);
 

--- a/apps/client/src/app/features/overview/components/date-bar/week-toggle-group.component.ts
+++ b/apps/client/src/app/features/overview/components/date-bar/week-toggle-group.component.ts
@@ -13,11 +13,7 @@ import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 
-import {
-  formatDateToYearMonthDay,
-  type CalendarWeek,
-  type DateString,
-} from '@lib/shared';
+import { formatDateToYearMonthDay, type DateString } from '@lib/shared';
 
 import { DateNavigationService } from '../../services';
 
@@ -138,7 +134,6 @@ const EXTERNAL_MODULES = [
 })
 export class WeekToggleGroupComponent {
   readonly selectedDay = input.required<DateString>();
-  readonly calendarWeek = input.required<CalendarWeek>();
   readonly weekdays = input.required<DateString[]>();
   readonly isLoading = input.required<boolean>();
 

--- a/apps/client/src/app/features/overview/services/date-navigation.service.spec.ts
+++ b/apps/client/src/app/features/overview/services/date-navigation.service.spec.ts
@@ -1,0 +1,183 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+
+import { getTodayDateString, type DateString } from '@lib/shared';
+
+import { DateNavigationService } from './date-navigation.service';
+import { SelectedDateService } from './selected-date.service';
+
+describe('DateNavigationService', () => {
+  const initialDate: DateString = '2026-08-10';
+  const sameWeekDate: DateString = '2026-08-12';
+  const nextWeekDate: DateString = '2026-08-17';
+
+  const selectedDay = signal<DateString>(initialDate);
+
+  const selectedDateServiceMock = {
+    selectedDay: selectedDay.asReadonly(),
+    setSelectedDay: jest.fn(),
+  };
+
+  const routerMock = {
+    url: `/${initialDate}`,
+    navigate: jest.fn(),
+  };
+
+  let service: DateNavigationService;
+
+  beforeEach(() => {
+    selectedDay.set(initialDate);
+
+    selectedDateServiceMock.setSelectedDay.mockClear();
+    routerMock.navigate.mockClear();
+    routerMock.url = `/${initialDate}`;
+
+    TestBed.configureTestingModule({
+      providers: [
+        DateNavigationService,
+        {
+          provide: SelectedDateService,
+          useValue: selectedDateServiceMock,
+        },
+        {
+          provide: Router,
+          useValue: routerMock,
+        },
+      ],
+    });
+
+    service = TestBed.inject(DateNavigationService);
+    TestBed.tick();
+  });
+
+  describe('weekdays', () => {
+    it('should expose all seven days of the selected week', () => {
+      expect(service.weekdays()).toEqual([
+        '2026-08-10',
+        '2026-08-11',
+        '2026-08-12',
+        '2026-08-13',
+        '2026-08-14',
+        '2026-08-15',
+        '2026-08-16',
+      ]);
+    });
+
+    it('should keep the weekdays reference when selected day changes within the same week', () => {
+      const weekdays = service.weekdays();
+
+      selectedDay.set(sameWeekDate);
+
+      expect(service.weekdays()).toBe(weekdays);
+    });
+
+    it('should create new weekdays when selected day changes to another week', () => {
+      const weekdays = service.weekdays();
+
+      selectedDay.set(nextWeekDate);
+
+      const nextWeekdays = service.weekdays();
+
+      expect(nextWeekdays).not.toBe(weekdays);
+      expect(nextWeekdays).toEqual([
+        '2026-08-17',
+        '2026-08-18',
+        '2026-08-19',
+        '2026-08-20',
+        '2026-08-21',
+        '2026-08-22',
+        '2026-08-23',
+      ]);
+    });
+  });
+
+  describe('selected tab', () => {
+    it('should expose the selected weekday index', () => {
+      expect(service.selectedTabIndex()).toBe(0);
+
+      selectedDay.set('2026-08-13');
+
+      expect(service.selectedTabIndex()).toBe(3);
+
+      selectedDay.set('2026-08-16');
+
+      expect(service.selectedTabIndex()).toBe(6);
+    });
+
+    it('should update the selected tab without recreating the week', () => {
+      const weekdays = service.weekdays();
+
+      selectedDay.set(sameWeekDate);
+
+      expect(service.selectedTabIndex()).toBe(2);
+      expect(service.weekdays()).toBe(weekdays);
+    });
+  });
+
+  describe('calendar week', () => {
+    it('should keep the calendar week key stable within the same week', () => {
+      const weekKey = service.calendarWeekKey();
+
+      selectedDay.set(sameWeekDate);
+
+      expect(service.calendarWeekKey()).toBe(weekKey);
+    });
+
+    it('should change the calendar week key when another week is selected', () => {
+      const weekKey = service.calendarWeekKey();
+
+      selectedDay.set(nextWeekDate);
+
+      expect(service.calendarWeekKey()).not.toBe(weekKey);
+    });
+  });
+
+  describe('today', () => {
+    it('should expose today', () => {
+      expect(service.today()).toBe(getTodayDateString());
+    });
+
+    it('should report whether the selected day is today', () => {
+      selectedDay.set(service.today());
+
+      expect(service.isToday()).toBe(true);
+
+      selectedDay.set(initialDate);
+
+      expect(service.isToday()).toBe(initialDate === service.today());
+    });
+
+    it('should reset the selected day to today', () => {
+      service.resetToday();
+
+      expect(selectedDateServiceMock.setSelectedDay).toHaveBeenCalledTimes(1);
+      expect(selectedDateServiceMock.setSelectedDay).toHaveBeenCalledWith(
+        service.today()
+      );
+    });
+  });
+
+  describe('route synchronization', () => {
+    it('should not navigate when the route already matches the selected day', () => {
+      expect(routerMock.navigate).not.toHaveBeenCalled();
+    });
+
+    it('should navigate when selected day changes', () => {
+      selectedDay.set(sameWeekDate);
+      TestBed.tick();
+
+      expect(routerMock.navigate).toHaveBeenCalledTimes(1);
+      expect(routerMock.navigate).toHaveBeenCalledWith([sameWeekDate]);
+    });
+
+    it('should not navigate when the route already matches a newly selected day', () => {
+      routerMock.url = `/${sameWeekDate}`;
+
+      selectedDay.set(sameWeekDate);
+      TestBed.tick();
+
+      expect(routerMock.navigate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/client/src/app/features/overview/services/date-navigation.service.ts
+++ b/apps/client/src/app/features/overview/services/date-navigation.service.ts
@@ -1,12 +1,11 @@
-import { DatePipe } from '@angular/common';
 import { Injectable, computed, effect, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
 
 import {
+  addDays,
   formatCalendarWeekKey,
   getTodayDateString,
-  startOfWeek,
-  type CalendarWeek,
+  getWeekStartFromKey,
   type DateString,
 } from '@lib/shared';
 
@@ -17,32 +16,26 @@ export class DateNavigationService {
   private readonly router = inject(Router);
   private readonly selectedDateService = inject(SelectedDateService);
 
-  readonly selectedTabIndex = computed<number>(() => {
-    return this.weekdays().findIndex(
-      (day) => day === this.selectedDateService.selectedDay()
-    );
-  });
-
   private readonly todaySignal = signal<DateString>(getTodayDateString());
   readonly today = this.todaySignal.asReadonly();
-
-  readonly isToday = computed<boolean>(
-    () => this.selectedDateService.selectedDay() === this.today()
-  );
-
-  readonly calendarWeek = computed<CalendarWeek>(() =>
-    this.getCalendarWeekFrom(this.selectedDateService.selectedDay())
-  );
 
   readonly calendarWeekKey = computed<string>(() =>
     formatCalendarWeekKey(this.selectedDateService.selectedDay())
   );
 
-  readonly weekdays = computed<DateString[]>(() => {
-    const selectedDay = this.selectedDateService.selectedDay();
+  readonly weekdays = computed<DateString[]>(() =>
+    this.createWeekDaysArray(this.calendarWeekKey())
+  );
 
-    return this.createWeekDaysArray(selectedDay);
-  });
+  readonly selectedTabIndex = computed<number>(() =>
+    this.weekdays().findIndex(
+      (day) => day === this.selectedDateService.selectedDay()
+    )
+  );
+
+  readonly isToday = computed<boolean>(
+    () => this.selectedDateService.selectedDay() === this.today()
+  );
 
   private readonly selectedDayEffect = effect(() => {
     const date = this.selectedDateService.selectedDay();
@@ -65,32 +58,9 @@ export class DateNavigationService {
     }
   }
 
-  private createWeekDaysArray(day: DateString): DateString[] {
-    const isStartOfWeek = startOfWeek(day);
+  private createWeekDaysArray(weekKey: string): DateString[] {
+    const weekStart = getWeekStartFromKey(weekKey);
 
-    return Array.from({ length: 7 }, (_, index) =>
-      isStartOfWeek.clone().add(index, 'days').format('YYYY-MM-DD')
-    );
-  }
-
-  private getCalendarWeekFrom(day: DateString): CalendarWeek {
-    try {
-      const datepipe = new DatePipe('de-DE');
-      const week = datepipe.transform(day, 'w');
-
-      if (!week) {
-        throw new Error(
-          `Invalid date: getCalendarWeekFrom(day: DateString): CalendarWeek | ${day}`
-        );
-      }
-
-      return Number(week);
-    } catch (error) {
-      console.error(
-        'Error calculating calendar week: getCalendarWeekFrom(day: DateString): CalendarWeek',
-        error
-      );
-      return 0;
-    }
+    return Array.from({ length: 7 }, (_, index) => addDays(weekStart, index));
   }
 }

--- a/apps/client/src/app/shared/components/footer/footer.component.ts
+++ b/apps/client/src/app/shared/components/footer/footer.component.ts
@@ -11,7 +11,7 @@ import { LogoComponent } from '../logo/logo.component';
   `,
   template: `
     <div>
-      <rs-logo class="animate-fade-in" disabled />
+      <rs-logo disabled />
     </div>
 
     <div></div>

--- a/apps/client/src/styles/styles.scss
+++ b/apps/client/src/styles/styles.scss
@@ -118,21 +118,6 @@ router-outlet + * {
   @apply h-[40px] justify-center;
 }
 
-.animate-fade-in {
-  animation-duration: 0.2s;
-  animation-name: animate-fade-in;
-  animation-fill-mode: backwards;
-}
-
-@keyframes animate-fade-in {
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
-}
-
 .animate-drop-from-top {
   animation-duration: 0.25s;
   animation-timing-function: ease-in-out;


### PR DESCRIPTION
- keep visible week data references stable within the same week
- avoid recreating weekday arrays on day changes
- remove fade-in animations from fixtures and standings
- use stable tracking keys for competition and standings lists
- optimize fixture grouping to a single pass
- remove unnecessary untracked usage from match day lists