### PR TITLE
test(e2e): mock realtime connections in client tests

### DIFF
--- a/apps/api/src/infrastructure/livestream.helper.ts
+++ b/apps/api/src/infrastructure/livestream.helper.ts
@@ -1,4 +1,5 @@
 import type { Realtime } from '@upstash/realtime';
+import type { Redis } from '@upstash/redis';
 import { z } from 'zod';
 
 import type {
@@ -6,7 +7,7 @@ import type {
   LiveFixtureUpdateDTO,
 } from '@lib/models';
 
-import { redis } from './redis.helper';
+import { getRedis } from './redis.helper';
 
 const realtimeSchema = {
   fixture: {
@@ -16,7 +17,7 @@ const realtimeSchema = {
 };
 
 type RealtimeInstance = Realtime<{
-  redis: typeof redis;
+  redis: Redis;
   schema: typeof realtimeSchema;
   maxDurationSecs: number;
 }>;
@@ -26,7 +27,7 @@ let realtimePromise: Promise<RealtimeInstance> | null = null;
 export const getRealtime = (): Promise<RealtimeInstance> => {
   realtimePromise ??= import('@upstash/realtime').then(({ Realtime }) => {
     return new Realtime({
-      redis,
+      redis: getRedis(),
       schema: realtimeSchema,
       maxDurationSecs: 300,
     });

--- a/apps/api/src/infrastructure/redis.helper.ts
+++ b/apps/api/src/infrastructure/redis.helper.ts
@@ -1,3 +1,9 @@
 import { Redis } from '@upstash/redis';
 
-export const redis: Redis = Redis.fromEnv();
+let redis: Redis | undefined;
+
+export const getRedis = (): Redis => {
+  redis ??= Redis.fromEnv();
+
+  return redis;
+};

--- a/apps/client-e2e/src/helpers/index.ts
+++ b/apps/client-e2e/src/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './realtime.helper';

--- a/apps/client-e2e/src/helpers/realtime.helper.ts
+++ b/apps/client-e2e/src/helpers/realtime.helper.ts
@@ -1,0 +1,77 @@
+import type { Page } from '@playwright/test';
+
+export const mockRealtimeConnected = async (page: Page): Promise<void> => {
+  await page.addInitScript(() => {
+    class MockEventSource {
+      static readonly CONNECTING = 0;
+      static readonly OPEN = 1;
+      static readonly CLOSED = 2;
+
+      readonly CONNECTING = 0;
+      readonly OPEN = 1;
+      readonly CLOSED = 2;
+
+      readonly url: string;
+      readonly withCredentials = false;
+
+      readyState = MockEventSource.CONNECTING;
+
+      onopen: ((event: Event) => void) | null = null;
+      onmessage: ((event: MessageEvent<string>) => void) | null = null;
+      onerror: ((event: Event) => void) | null = null;
+
+      constructor(url: string | URL) {
+        this.url = url.toString();
+
+        setTimeout(() => {
+          this.readyState = MockEventSource.OPEN;
+          this.onopen?.(new Event('open'));
+        });
+      }
+
+      close(): void {
+        this.readyState = MockEventSource.CLOSED;
+      }
+
+      addEventListener(): void {
+        // empty
+      }
+
+      removeEventListener(): void {
+        // empty
+      }
+
+      dispatchEvent(): boolean {
+        return true;
+      }
+    }
+
+    window.EventSource = MockEventSource as unknown as typeof EventSource;
+  });
+};
+
+export const mockRealtimeUnavailable = async (page: Page): Promise<void> => {
+  await page.addInitScript(() => {
+    class MockEventSource {
+      readonly url: string;
+
+      onopen: ((event: Event) => void) | null = null;
+      onmessage: ((event: MessageEvent<string>) => void) | null = null;
+      onerror: ((event: Event) => void) | null = null;
+
+      constructor(url: string | URL) {
+        this.url = url.toString();
+
+        setTimeout(() => {
+          this.onerror?.(new Event('error'));
+        });
+      }
+
+      close(): void {
+        // empty
+      }
+    }
+
+    window.EventSource = MockEventSource as unknown as typeof EventSource;
+  });
+};

--- a/apps/client-e2e/src/pages/overview.page.ts
+++ b/apps/client-e2e/src/pages/overview.page.ts
@@ -107,62 +107,6 @@ export class OverviewPage {
     });
   }
 
-  async mockRealtimeConnected(): Promise<void> {
-    await this.page.addInitScript(() => {
-      class MockEventSource {
-        static readonly CONNECTING = 0;
-        static readonly OPEN = 1;
-        static readonly CLOSED = 2;
-
-        readonly CONNECTING = 0;
-        readonly OPEN = 1;
-        readonly CLOSED = 2;
-
-        readonly url: string;
-        readonly withCredentials = false;
-
-        readyState = MockEventSource.CONNECTING;
-
-        onopen: ((event: Event) => void) | null = null;
-        onmessage: ((event: MessageEvent<string>) => void) | null = null;
-        onerror: ((event: Event) => void) | null = null;
-
-        constructor(url: string | URL) {
-          this.url = url.toString();
-
-          setTimeout(() => {
-            this.readyState = MockEventSource.OPEN;
-            this.onopen?.(new Event('open'));
-          });
-        }
-
-        close(): void {
-          this.readyState = MockEventSource.CLOSED;
-        }
-
-        addEventListener(): void {
-          /* empty */
-        }
-
-        removeEventListener(): void {
-          /* empty */
-        }
-
-        dispatchEvent(): boolean {
-          return true;
-        }
-      }
-
-      window.EventSource = MockEventSource as unknown as typeof EventSource;
-    });
-  }
-
-  async mockRealtimeUnavailable(): Promise<void> {
-    await this.page.route('**/livestream', async (route) => {
-      await route.abort('connectionrefused');
-    });
-  }
-
   getFirstFixture(): Locator {
     return this.fixtureItems.first();
   }

--- a/apps/client-e2e/src/tests/overview/auto-refresh.spec.ts
+++ b/apps/client-e2e/src/tests/overview/auto-refresh.spec.ts
@@ -1,5 +1,6 @@
 import test, { expect } from '@playwright/test';
 
+import { mockRealtimeConnected, mockRealtimeUnavailable } from '../../helpers';
 import { OverviewPage } from '../../pages';
 
 const testDate = '2023-11-02';
@@ -26,7 +27,7 @@ test.describe('Overview Page', () => {
   }) => {
     const overviewPage = new OverviewPage(page);
 
-    await overviewPage.mockRealtimeConnected();
+    await mockRealtimeConnected(page);
     await overviewPage.mockSelectedDayAsPlaying(testDate);
 
     await overviewPage.goto(testDate);
@@ -44,8 +45,10 @@ test.describe('Overview Page', () => {
 
     const overviewPage = new OverviewPage(page);
 
-    await overviewPage.mockRealtimeUnavailable();
+    await mockRealtimeUnavailable(page);
     await overviewPage.mockSelectedDayAsPlaying(testDate);
+
+    await overviewPage.goto(testDate);
 
     await overviewPage.goto(testDate);
     await overviewPage.expectLoaded();
@@ -81,7 +84,7 @@ test.describe('Overview Page', () => {
 
     const targetTimerValue = AUTO_REFRESH_INTERVAL_SECONDS - 5;
 
-    await overviewPage.mockRealtimeUnavailable();
+    await mockRealtimeUnavailable(page);
     await overviewPage.mockSelectedDayAsPlaying(testDate);
 
     await overviewPage.goto(testDate);

--- a/apps/client-e2e/src/tests/overview/navigation.spec.ts
+++ b/apps/client-e2e/src/tests/overview/navigation.spec.ts
@@ -1,5 +1,6 @@
 import test, { expect, type Request } from '@playwright/test';
 
+import { mockRealtimeConnected } from '../../helpers';
 import { MatchPage, OverviewPage } from '../../pages';
 
 const testDate = '2026-08-11';
@@ -16,6 +17,8 @@ test.describe('Overview Page', () => {
   }) => {
     const overviewPage = new OverviewPage(page);
     const matchPage = new MatchPage(page);
+
+    await mockRealtimeConnected(page);
 
     await overviewPage.goto(testDate);
 


### PR DESCRIPTION
* avoid real Upstash connections during E2E tests
* add connected and unavailable EventSource mocks
* test polling only as realtime fallback
* keep realtime-connected tests independent from Redis