### PR TITLE
fix(client): stop realtime retries after fallback

### DIFF
--- a/apps/client-e2e/src/helpers/realtime.helper.ts
+++ b/apps/client-e2e/src/helpers/realtime.helper.ts
@@ -7,10 +7,6 @@ export const mockRealtimeConnected = async (page: Page): Promise<void> => {
       static readonly OPEN = 1;
       static readonly CLOSED = 2;
 
-      readonly CONNECTING = 0;
-      readonly OPEN = 1;
-      readonly CLOSED = 2;
-
       readonly url: string;
       readonly withCredentials = false;
 
@@ -24,6 +20,10 @@ export const mockRealtimeConnected = async (page: Page): Promise<void> => {
         this.url = url.toString();
 
         setTimeout(() => {
+          if (this.readyState === MockEventSource.CLOSED) {
+            return;
+          }
+
           this.readyState = MockEventSource.OPEN;
           this.onopen?.(new Event('open'));
         });
@@ -53,22 +53,60 @@ export const mockRealtimeConnected = async (page: Page): Promise<void> => {
 export const mockRealtimeUnavailable = async (page: Page): Promise<void> => {
   await page.addInitScript(() => {
     class MockEventSource {
+      static readonly CONNECTING = 0;
+      static readonly OPEN = 1;
+      static readonly CLOSED = 2;
+
       readonly url: string;
+      readonly withCredentials = false;
+
+      readyState = MockEventSource.CONNECTING;
 
       onopen: ((event: Event) => void) | null = null;
       onmessage: ((event: MessageEvent<string>) => void) | null = null;
       onerror: ((event: Event) => void) | null = null;
 
+      private retryTimeout?: ReturnType<typeof setTimeout>;
+
       constructor(url: string | URL) {
         this.url = url.toString();
 
-        setTimeout(() => {
-          this.onerror?.(new Event('error'));
-        });
+        this.emitErrors(3);
       }
 
       close(): void {
+        this.readyState = MockEventSource.CLOSED;
+
+        if (this.retryTimeout !== undefined) {
+          clearTimeout(this.retryTimeout);
+          this.retryTimeout = undefined;
+        }
+      }
+
+      addEventListener(): void {
         // empty
+      }
+
+      removeEventListener(): void {
+        // empty
+      }
+
+      dispatchEvent(): boolean {
+        return true;
+      }
+
+      private emitErrors(remainingErrors: number): void {
+        this.retryTimeout = setTimeout(() => {
+          if (this.readyState === MockEventSource.CLOSED) {
+            return;
+          }
+
+          this.onerror?.(new Event('error'));
+
+          if (remainingErrors > 1) {
+            this.emitErrors(remainingErrors - 1);
+          }
+        }, 50);
       }
     }
 

--- a/apps/client-e2e/src/tests/overview/auto-refresh.spec.ts
+++ b/apps/client-e2e/src/tests/overview/auto-refresh.spec.ts
@@ -49,8 +49,6 @@ test.describe('Overview Page', () => {
     await overviewPage.mockSelectedDayAsPlaying(testDate);
 
     await overviewPage.goto(testDate);
-
-    await overviewPage.goto(testDate);
     await overviewPage.expectLoaded();
     await overviewPage.expectRefreshTimerRunning();
 
@@ -111,7 +109,6 @@ test.describe('Overview Page', () => {
     const restoredTimer = await overviewPage.getRefreshTimerValue();
 
     expect(restoredTimer).toBeLessThanOrEqual(timerBeforeNavigation);
-
     expect(restoredTimer).toBeGreaterThanOrEqual(timerBeforeNavigation - 1);
 
     await expect

--- a/apps/client/src/app/shared/services/realtime.service.spec.ts
+++ b/apps/client/src/app/shared/services/realtime.service.spec.ts
@@ -99,34 +99,6 @@ describe('RealtimeService', () => {
     expect(liveRefreshServiceMock.stop).toHaveBeenCalledTimes(1);
   });
 
-  it('should enable polling fallback and refresh immediately on realtime error', () => {
-    service.connect();
-
-    const eventSource = getEventSource();
-
-    eventSource.emitError();
-
-    expect(service.status()).toBe('error');
-    expect(liveRefreshServiceMock.start).toHaveBeenCalledTimes(1);
-
-    expect(liveRefreshServiceMock.refresh).toHaveBeenCalledWith({
-      force: true,
-    });
-  });
-
-  it('should disable polling fallback again after reconnect', () => {
-    service.connect();
-
-    const eventSource = getEventSource();
-
-    eventSource.emitError();
-    eventSource.emitOpen();
-
-    expect(service.status()).toBe('connected');
-    expect(liveRefreshServiceMock.start).toHaveBeenCalledTimes(1);
-    expect(liveRefreshServiceMock.stop).toHaveBeenCalledTimes(1);
-  });
-
   it('should expose fixture updates', () => {
     const update = createFixtureUpdate(123);
 
@@ -169,6 +141,59 @@ describe('RealtimeService', () => {
 
     expect(service.fixtureUpdate()).toBeNull();
     expect(service.fixtureEventsUpdate()).toBeNull();
+  });
+
+  it('should not enable polling before reaching the realtime error limit', () => {
+    service.connect();
+
+    const eventSource = getEventSource();
+
+    eventSource.emitError();
+    eventSource.emitError();
+
+    expect(service.status()).toBe('error');
+
+    expect(eventSource.close).not.toHaveBeenCalled();
+
+    expect(liveRefreshServiceMock.start).not.toHaveBeenCalled();
+    expect(liveRefreshServiceMock.refresh).not.toHaveBeenCalled();
+  });
+
+  it('should permanently fall back to polling after reaching the realtime error limit', () => {
+    service.connect();
+
+    const eventSource = getEventSource();
+
+    eventSource.emitError();
+    eventSource.emitError();
+    eventSource.emitError();
+
+    expect(service.status()).toBe('fallback');
+
+    expect(eventSource.close).toHaveBeenCalledTimes(1);
+
+    expect(liveRefreshServiceMock.start).toHaveBeenCalledTimes(1);
+
+    expect(liveRefreshServiceMock.refresh).toHaveBeenCalledTimes(1);
+    expect(liveRefreshServiceMock.refresh).toHaveBeenCalledWith({
+      force: true,
+    });
+  });
+
+  it('should not reconnect realtime after falling back to polling', () => {
+    service.connect();
+
+    const eventSource = getEventSource();
+
+    eventSource.emitError();
+    eventSource.emitError();
+    eventSource.emitError();
+
+    service.connect();
+    service.connect();
+
+    expect(service.status()).toBe('fallback');
+    expect(MockEventSource.instances).toHaveLength(1);
   });
 
   it('should disconnect realtime and enable polling fallback', () => {

--- a/apps/client/src/app/shared/services/realtime.service.ts
+++ b/apps/client/src/app/shared/services/realtime.service.ts
@@ -14,7 +14,8 @@ export type RealtimeStatus =
   | 'disconnected'
   | 'connecting'
   | 'connected'
-  | 'error';
+  | 'error'
+  | 'fallback';
 
 type RealtimeEnvelope<T> = {
   id: string;
@@ -22,6 +23,8 @@ type RealtimeEnvelope<T> = {
   event: string;
   data: T;
 };
+
+const MAX_CONNECTION_ERRORS = 3;
 
 const parseOperationTime = (time: Date | string): Date => {
   return time instanceof Date ? time : new Date(time);
@@ -41,8 +44,12 @@ export class RealtimeService {
 
   private eventSource?: EventSource;
 
+  private connectionErrors = 0;
+
+  private realtimeDisabled = false;
+
   connect(): void {
-    if (this.eventSource) {
+    if (this.eventSource || this.realtimeDisabled) {
       return;
     }
 
@@ -53,19 +60,18 @@ export class RealtimeService {
     this.eventSource = eventSource;
 
     eventSource.onopen = (): void => {
+      if (this.realtimeDisabled) {
+        eventSource.close();
+        return;
+      }
+
       this.status.set('connected');
 
       this.liveRefreshService.stop();
     };
 
     eventSource.onerror = (): void => {
-      this.status.set('error');
-
-      this.liveRefreshService.start();
-
-      void this.liveRefreshService.refresh({
-        force: true,
-      });
+      this.handleConnectionError();
     };
 
     eventSource.onmessage = (event: MessageEvent<string>): void => {
@@ -74,12 +80,42 @@ export class RealtimeService {
   }
 
   disconnect(): void {
-    this.eventSource?.close();
-    this.eventSource = undefined;
+    this.closeEventSource();
 
     this.status.set('disconnected');
 
     this.liveRefreshService.start();
+  }
+
+  private handleConnectionError(): void {
+    this.connectionErrors++;
+
+    if (this.connectionErrors < MAX_CONNECTION_ERRORS) {
+      this.status.set('error');
+
+      return;
+    }
+
+    this.fallbackToRefresh();
+  }
+
+  private fallbackToRefresh(): void {
+    this.realtimeDisabled = true;
+
+    this.closeEventSource();
+
+    this.status.set('fallback');
+
+    this.liveRefreshService.start();
+
+    void this.liveRefreshService.refresh({
+      force: true,
+    });
+  }
+
+  private closeEventSource(): void {
+    this.eventSource?.close();
+    this.eventSource = undefined;
   }
 
   private handleMessage(data: string): void {


### PR DESCRIPTION
- stop realtime retries after reaching the error limit
- keep polling fallback active for the current session
- update realtime and auto-refresh tests
- remove duplicate overview navigation in auto-refresh e2e